### PR TITLE
feat: Set brightness to zero before blacking out

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,58 +9,75 @@ A simple but powerful tool for Windows users to prevent OLED burn-in and create 
 </p>
 
 ---
+
 ## The Problem
 
 OLED displays are susceptible to permanent image retention (burn-in) from static images. Additionally, many power users want to turn off secondary monitors for focus or gaming without putting the entire computer to sleep. Standard Windows power settings can't do this; it's all or nothing.
 
 ---
+
 ## The Solution
 
-OLED Sleeper runs quietly in the background, monitoring user activity on a per-screen basis. If a designated monitor is idle for a user-defined period, the script will either overlay it with a pure black screen or reduce its brightness — depending on your chosen mode.
+OLED Sleeper runs quietly in the background, checking for activity (mouse movement or active window presence) on each screen. If a designated monitor remains idle for a user-defined period, the script will either overlay it with a pure black screen or reduce its brightness — depending on your chosen mode.
 
-This is not only essential for **protecting OLEDs** but is also perfect for any user (with **LCD or OLED**) who wants to create a focused environment by selectively blacking out or dimming monitors—a feature Windows doesn't offer.
+This is useful not only for **protecting OLEDs**, but also for creating a more focused environment on any multi-monitor setup.
 
 ---
-### Features
+
+## How It Works
+
+The script checks for:
+
+- **Mouse movement** over each monitor
+- **Active window focus** on that monitor
+
+If neither is detected for a set time, the monitor is considered idle. No other input is monitored.
+
+---
+
+## Features
 
 * **Per-Monitor Control:** Choose exactly which monitors to manage.
 * **Adjustable Idle Timer:** Set any idle duration you want.
 * **Two Idle Modes:** Choose between full **blackout** or brightness **dimming** for each monitor.
 * **Instant Wake-Up:** Overlays are removed and brightness is restored the moment activity is detected.
-* **Lightweight:** The background script has a tiny memory and CPU footprint.
+* **Lightweight:** Uses minimal memory and CPU.
 * **Simple Setup:** A user-friendly wizard walks you through the initial configuration.
 
 ---
+
 ## Requirements
 
-* **Operating System:** Windows 10 or 11.
-* **Dependency:** **[AutoHotkey v2](https://www.autohotkey.com/)** must be installed on your system.
-* **DDC/CI Support (Required for Dimming Only):** Dimming mode requires a monitor that supports DDC/CI brightness control via VCP codes. Most modern OLED monitors support this, but it is not guaranteed on all displays.
+* **Operating System:** Windows 10 or 11
+* **Dependency:** [AutoHotkey v2](https://www.autohotkey.com/) must be installed
+* **DDC/CI Support (for Dimming Mode):** Dimming requires a monitor that supports DDC/CI brightness control via VCP codes. Most modern OLED monitors support this, but it is not guaranteed on all displays.
 
 ---
+
 ## How to Use
 
-1.  Download the latest release from the [Releases page](https://github.com/Quorthon13/OLED-Sleeper/releases) or clone this repository.
-2.  Unzip the folder to a permanent location on your computer.
-3.  Double-click **`setup.bat`**.
-4.  Follow the on-screen instructions to select your target monitors, choose blackout or dim mode, and set an idle timer.
+1. Download the latest release from the [Releases page](https://github.com/Quorthon13/OLED-Sleeper/releases) or clone this repository.
+2. Unzip the folder to a permanent location on your computer.
+3. Double-click **`setup.bat`**.
+4. Follow the on-screen instructions to select your target monitors, choose blackout or dim mode, and set an idle timer.
 
-That's it! The script will now run in the background and monitor your displays for the rest of your session.
+That's it. The script will now run in the background and monitor your displays for the rest of your session.
 
 **Note:** To re-launch the watcher after a restart, simply run **`setup.bat`** again.
 
 ---
+
 ## Credits
 
 This project relies on the excellent utilities developed by **NirSoft**:
 
-- [`MultiMonitorTool.exe`](https://www.nirsoft.net/utils/multi_monitor_tool.html)
-- [`ControlMyMonitor.exe`](https://www.nirsoft.net/utils/control_my_monitor.html)
+- [`MultiMonitorTool`](https://www.nirsoft.net/utils/multi_monitor_tool.html)
+- [`ControlMyMonitor`](https://www.nirsoft.net/utils/control_my_monitor.html)
 
 You can find more of their work at [www.nirsoft.net](https://www.nirsoft.net).
 
-
 ---
+
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License – see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
The tool will set brightness to zero before blacking out. 
Very useful for non-OLED screens as it reduces the amount of light emitted from the display's backlight.