### PR TITLE
WIP: Add support for observing monitor content change

### DIFF
--- a/OLED-Sleeper/Features/MonitorIdleDetection/Models/ActivityReason.cs
+++ b/OLED-Sleeper/Features/MonitorIdleDetection/Models/ActivityReason.cs
@@ -24,6 +24,11 @@
         /// <summary>
         /// System input (keyboard or mouse activity) was detected.
         /// </summary>
-        SystemInput
+        SystemInput,
+
+        /// <summary>
+        /// Monitor content changed
+        /// </summary>
+        ContentChange,
     }
 }

--- a/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
+++ b/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
@@ -90,13 +90,13 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
                                         {
                                             Settings = setting,
                                             Bounds = monitorInfo.Bounds,
-                                            WorkingArea = monitorInfo.WorkingArea,
                                             DisplayNumber = monitorInfo.DisplayNumber
                                         }).ToList();
 
                     _monitorStates.Clear();
                     foreach (var monitor in _managedMonitors)
                     {
+                        monitor.InitializeBuffers(128);
                         _monitorStates[monitor.Settings.HardwareId] = new MonitorTimerState();
                     }
                 }
@@ -289,138 +289,94 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
             return false;
         }
 
-        private static uint GetDownsampledScreenHash(Rect bounds, int skipPixels = 32)
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetDC(IntPtr hwnd);
+
+        [DllImport("user32.dll")]
+        private static extern int ReleaseDC(IntPtr hwnd, IntPtr hdc);
+
+        [DllImport("gdi32.dll")]
+        private static extern bool StretchBlt(IntPtr hdcDest, int nXOriginDest, int nYOriginDest, int nWidthDest, int nHeightDest,
+            IntPtr hdcSrc, int nXOriginSrc, int nYOriginSrc, int nWidthSrc, int nHeightSrc, int dwRop);
+
+        [DllImport("gdi32.dll")]
+        private static extern int SetStretchBltMode(IntPtr hdc, int iStretchMode);
+
+        private const int SRCCOPY = 0x00CC0020;
+        private const int COLORONCOLOR = 3;
+        private const int CaptureIntervalMilliseconds = 1000;
+
+
+        /// <summary>
+        /// Gets a shrinked screenshot and returns percentage of changed pixels
+        /// </summary>
+        private static unsafe double GetPixelDifferenceShrinked(ManagedMonitorState monitor)
         {
-            System.Drawing.Rectangle drawingBounds = new System.Drawing.Rectangle(
-                (int)bounds.X,
-                (int)bounds.Y,
-                (int)bounds.Width,
-                (int)bounds.Height
-                );
+            IntPtr hdcSrc = GetDC(IntPtr.Zero);
 
-            using (Bitmap bmp = new Bitmap((int)bounds.Width, (int)bounds.Height, PixelFormat.Format32bppArgb))
+            using (Graphics g = Graphics.FromImage(monitor.DownsampledBitmap))
             {
-                using (Graphics g = Graphics.FromImage(bmp))
-                {
-                    g.CopyFromScreen(drawingBounds.Location, System.Drawing.Point.Empty, drawingBounds.Size);
+
+                IntPtr hdcDest = g.GetHdc();
+                SetStretchBltMode(hdcDest, COLORONCOLOR);
+                StretchBlt(hdcDest, 0, 0, monitor.SampledWidth, monitor.SampledHeight,
+                           hdcSrc, (int)monitor.Bounds.X, (int)monitor.Bounds.Y, (int)monitor.Bounds.Width, (int)monitor.Bounds.Height,
+                           SRCCOPY);
+                g.ReleaseHdc(hdcDest);
                 }
+            ReleaseDC(IntPtr.Zero, hdcSrc);
 
-                BitmapData bmpData = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.ReadOnly, bmp.PixelFormat);
-                int bytes = Math.Abs(bmpData.Stride) * bmp.Height;
-                byte[] allPixels = new byte[bytes];
-                Marshal.Copy(bmpData.Scan0, allPixels, 0, bytes);
-                bmp.UnlockBits(bmpData);
+            var bmpData = monitor.DownsampledBitmap.LockBits(
+                new System.Drawing.Rectangle(0, 0, monitor.SampledWidth, monitor.SampledHeight),
+                ImageLockMode.ReadOnly,
+                PixelFormat.Format32bppArgb);
 
-                uint hash = 2166136261;
-                const uint fnvPrime = 16777619;
-
-                int stride = Math.Abs(bmpData.Stride);
-
-                for (int y = 0; y < bmp.Height; y += skipPixels)
-                {
-                    for (int x = 0; x < bmp.Width; x += skipPixels)
-                    {
-                        int offset = (y * stride) + (x * 4);
-                        byte pixelValue = allPixels[offset];
-
-                        hash ^= pixelValue;
-                        hash *= fnvPrime;
-                    }
-                }
-
-                return hash;
-            }
-        }
-
-        private static double GetPixelDifferencePercentage(System.Windows.Rect bounds, ref byte[]? lastFramePixels, int skipPixels = 32)
-        {
-            System.Drawing.Rectangle drawingBounds = new System.Drawing.Rectangle(
-                (int)bounds.X, (int)bounds.Y, (int)bounds.Width, (int)bounds.Height);
-
-            using (Bitmap bmp = new Bitmap(drawingBounds.Width, drawingBounds.Height, PixelFormat.Format32bppArgb))
-            {
-                using (Graphics g = Graphics.FromImage(bmp))
-                {
-                    g.CopyFromScreen(drawingBounds.Location, System.Drawing.Point.Empty, drawingBounds.Size);
-                }
-
-                BitmapData bmpData = bmp.LockBits(new System.Drawing.Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.ReadOnly, bmp.PixelFormat);
-                int bytes = Math.Abs(bmpData.Stride) * bmp.Height;
-                byte[] allPixels = new byte[bytes];
-                Marshal.Copy(bmpData.Scan0, allPixels, 0, bytes);
-                bmp.UnlockBits(bmpData);
-
-                int sampledWidth = bmp.Width / skipPixels;
-                int sampledHeight = bmp.Height / skipPixels;
-                int totalSampledPixels = sampledWidth * sampledHeight;
-
-                if (lastFramePixels == null || lastFramePixels.Length != totalSampledPixels)
-                {
-                    lastFramePixels = new byte[totalSampledPixels];
-                }
-
+            int totalPixels = monitor.SampledWidth * monitor.SampledHeight;
                 int changedPixelsCount = 0;
-                int pixelIndex = 0;
-                int stride = Math.Abs(bmpData.Stride);
 
-                for (int y = 0; y < bmp.Height && pixelIndex < totalSampledPixels; y += skipPixels)
+            byte* ptr = (byte*)bmpData.Scan0;
+
+            for (int i = 0; i < totalPixels; i++)
                 {
-                    for (int x = 0; x < bmp.Width && pixelIndex < totalSampledPixels; x += skipPixels)
-                    {
-                        int offset = (y * stride) + (x * 4);
-                        byte currentPixel = allPixels[offset];
+                byte currentPixel = ptr[i * 4];
 
-                        if (Math.Abs(currentPixel - lastFramePixels[pixelIndex]) > 5)
+                if (Math.Abs(currentPixel - monitor.LastFramePixels[i]) > 5)
                         {
                             changedPixelsCount++;
                         }
 
-                        lastFramePixels[pixelIndex] = currentPixel;
-                        pixelIndex++;
+                monitor.LastFramePixels[i] = currentPixel;
                     }
-                }
 
-                return ((double)changedPixelsCount / totalSampledPixels) * 100.0;
+            monitor.DownsampledBitmap.UnlockBits(bmpData);
+
+            if (changedPixelsCount == 0) return 0.0;
+            return ((double)changedPixelsCount / totalPixels) * 100.0;
             }
         }
 
-        private static bool checkPixelHash(ManagedMonitorState monitor, Rect rect)
+        /// <summary>
+        /// Checks if content change should trigger activity for the monitor.
+        /// </summary>
+        private static bool IsContentChange(ManagedMonitorState monitor, MonitorTimerState timerState)
         {
-            uint newHash = GetDownsampledScreenHash(rect);
+            // If the monitor is in idle state and it gets black this would trigger content change, so it is only available to keep it active but not to activate it
 
-            if (newHash != monitor.lastHash)
+            if (monitor.Settings.IsActiveOnContentChange && timerState.CurrentState != MonitorStateMachine.Idle) {
+                var now = DateTime.UtcNow;
+                if ((now - timerState.LastCaptureTimestamp).TotalMilliseconds < CaptureIntervalMilliseconds)
             {
-                monitor.lastHash = newHash;
-                return true;
-            }
             return false;
         }
 
-        private static bool checkPixelDifference(ManagedMonitorState monitor, Rect rect)
-        {
             byte[]? pixels = monitor.LastFramePixels;
-            double changedPercentage = GetPixelDifferencePercentage(rect, ref pixels);
+                double changedPercentage = GetPixelDifferenceShrinked(monitor);
             monitor.LastFramePixels = pixels;
-            System.Diagnostics.Debug.WriteLine($"Change: {changedPercentage}%");
             if (changedPercentage > 1.0)
             {
                 return true;
             }
-            return false;
         }
-
-        private static bool IsContentChange(ManagedMonitorState monitor, MonitorTimerState timerState)
-        {
-            // If the monitor is in idle state and it gets black this would trigger content change, so it is only available to keep it active but not to activate it
-            if (monitor.Settings.IsActiveOnContentChange && timerState.CurrentState != MonitorStateMachine.Idle) {
-
-                Rect rect = monitor.WorkingArea; // without taskbar
-                // Rect rect = monitor.Bounds; // with taskbar
-
-                // return checkPixelHash(monitor, rect);
-                return checkPixelDifference(monitor, rect);
-
-            }
             return false;
         }
 
@@ -494,9 +450,19 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
             public int DisplayNumber { get; set; }
             public MonitorSettings Settings { get; set; }
             public Rect Bounds { get; set; }
-            public uint lastHash { get; set; }
-            public Rect WorkingArea { get; set; }
-            public byte[]? LastFramePixels { get; set; }
+            
+            public System.Drawing.Bitmap? DownsampledBitmap;
+            public byte[]? LastFramePixels;
+            public int SampledWidth;
+            public int SampledHeight;
+            
+            public void InitializeBuffers(int skipPixels)
+            {
+                SampledWidth = (int)Bounds.Width / skipPixels;
+                SampledHeight = (int)Bounds.Height / skipPixels;
+                DownsampledBitmap = new System.Drawing.Bitmap(SampledWidth, SampledHeight, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+                LastFramePixels = new byte[SampledWidth * SampledHeight];
+            }
         }
 
         /// <summary>
@@ -506,6 +472,8 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         {
             public MonitorStateMachine CurrentState { get; set; } = MonitorStateMachine.Active;
             public DateTime ActivityStoppedTimestamp { get; set; }
+            // Timestamp of the last native capture performed for this monitor.
+            public DateTime LastCaptureTimestamp { get; set; } = DateTime.MinValue;
         }
 
         /// <summary>

--- a/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
+++ b/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
@@ -7,6 +7,7 @@ using OLED_Sleeper.Features.MonitorInformation.Services.Interfaces;
 using OLED_Sleeper.Features.UserSettings.Models;
 using OLED_Sleeper.Native;
 using Serilog;
+using System.Diagnostics.Eventing.Reader;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
@@ -89,6 +90,7 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
                                         {
                                             Settings = setting,
                                             Bounds = monitorInfo.Bounds,
+                                            WorkingArea = monitorInfo.WorkingArea,
                                             DisplayNumber = monitorInfo.DisplayNumber
                                         }).ToList();
 
@@ -287,7 +289,7 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
             return false;
         }
 
-        private static uint GetDownsampledScreenHash(Rect bounds, int skipPixels = 64)
+        private static uint GetDownsampledScreenHash(Rect bounds, int skipPixels = 32)
         {
             System.Drawing.Rectangle drawingBounds = new System.Drawing.Rectangle(
                 (int)bounds.X,
@@ -330,15 +332,94 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
             }
         }
 
+        private static double GetPixelDifferencePercentage(System.Windows.Rect bounds, ref byte[]? lastFramePixels, int skipPixels = 32)
+        {
+            System.Drawing.Rectangle drawingBounds = new System.Drawing.Rectangle(
+                (int)bounds.X, (int)bounds.Y, (int)bounds.Width, (int)bounds.Height);
+
+            using (Bitmap bmp = new Bitmap(drawingBounds.Width, drawingBounds.Height, PixelFormat.Format32bppArgb))
+            {
+                using (Graphics g = Graphics.FromImage(bmp))
+                {
+                    g.CopyFromScreen(drawingBounds.Location, System.Drawing.Point.Empty, drawingBounds.Size);
+                }
+
+                BitmapData bmpData = bmp.LockBits(new System.Drawing.Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.ReadOnly, bmp.PixelFormat);
+                int bytes = Math.Abs(bmpData.Stride) * bmp.Height;
+                byte[] allPixels = new byte[bytes];
+                Marshal.Copy(bmpData.Scan0, allPixels, 0, bytes);
+                bmp.UnlockBits(bmpData);
+
+                int sampledWidth = bmp.Width / skipPixels;
+                int sampledHeight = bmp.Height / skipPixels;
+                int totalSampledPixels = sampledWidth * sampledHeight;
+
+                if (lastFramePixels == null || lastFramePixels.Length != totalSampledPixels)
+                {
+                    lastFramePixels = new byte[totalSampledPixels];
+                }
+
+                int changedPixelsCount = 0;
+                int pixelIndex = 0;
+                int stride = Math.Abs(bmpData.Stride);
+
+                for (int y = 0; y < bmp.Height && pixelIndex < totalSampledPixels; y += skipPixels)
+                {
+                    for (int x = 0; x < bmp.Width && pixelIndex < totalSampledPixels; x += skipPixels)
+                    {
+                        int offset = (y * stride) + (x * 4);
+                        byte currentPixel = allPixels[offset];
+
+                        if (Math.Abs(currentPixel - lastFramePixels[pixelIndex]) > 5)
+                        {
+                            changedPixelsCount++;
+                        }
+
+                        lastFramePixels[pixelIndex] = currentPixel;
+                        pixelIndex++;
+                    }
+                }
+
+                return ((double)changedPixelsCount / totalSampledPixels) * 100.0;
+            }
+        }
+
+        private static bool checkPixelHash(ManagedMonitorState monitor, Rect rect)
+        {
+            uint newHash = GetDownsampledScreenHash(rect);
+
+            if (newHash != monitor.lastHash)
+            {
+                monitor.lastHash = newHash;
+                return true;
+            }
+            return false;
+        }
+
+        private static bool checkPixelDifference(ManagedMonitorState monitor, Rect rect)
+        {
+            byte[]? pixels = monitor.LastFramePixels;
+            double changedPercentage = GetPixelDifferencePercentage(rect, ref pixels);
+            monitor.LastFramePixels = pixels;
+            System.Diagnostics.Debug.WriteLine($"Change: {changedPercentage}%");
+            if (changedPercentage > 1.0)
+            {
+                return true;
+            }
+            return false;
+        }
+
         private static bool IsContentChange(ManagedMonitorState monitor, MonitorTimerState timerState)
         {
             // If the monitor is in idle state and it gets black this would trigger content change, so it is only available to keep it active but not to activate it
-            if (monitor.Settings.IsActiveOnContentChange && timerState.CurrentState != MonitorStateMachine.Idle) { 
-                uint newHash = GetDownsampledScreenHash(monitor.Bounds);
-                if (newHash != monitor.lastHash) {
-                    monitor.lastHash = newHash;
-                    return true;
-                }
+            if (monitor.Settings.IsActiveOnContentChange && timerState.CurrentState != MonitorStateMachine.Idle) {
+
+                Rect rect = monitor.WorkingArea; // without taskbar
+                // Rect rect = monitor.Bounds; // with taskbar
+
+                // return checkPixelHash(monitor, rect);
+                return checkPixelDifference(monitor, rect);
+
             }
             return false;
         }
@@ -414,6 +495,8 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
             public MonitorSettings Settings { get; set; }
             public Rect Bounds { get; set; }
             public uint lastHash { get; set; }
+            public Rect WorkingArea { get; set; }
+            public byte[]? LastFramePixels { get; set; }
         }
 
         /// <summary>

--- a/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
+++ b/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
@@ -7,6 +7,8 @@ using OLED_Sleeper.Features.MonitorInformation.Services.Interfaces;
 using OLED_Sleeper.Features.UserSettings.Models;
 using OLED_Sleeper.Native;
 using Serilog;
+using System.Drawing;
+using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 using System.Windows;
 
@@ -149,7 +151,7 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         private void ProcessSingleMonitor(ManagedMonitorState monitor, SystemState systemState)
         {
             var timerState = _monitorStates[monitor.Settings.HardwareId];
-            var activityReason = GetActivityReason(monitor, systemState);
+            var activityReason = GetActivityReason(monitor, systemState, timerState);
             bool hasActivityNow = activityReason != ActivityReason.None;
 
             var eventArgs = new MonitorIdleStateEventArgs(
@@ -242,7 +244,7 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         /// <param name="monitor">The managed monitor.</param>
         /// <param name="state">Current system state.</param>
         /// <returns>The activity reason.</returns>
-        private static ActivityReason GetActivityReason(ManagedMonitorState monitor, SystemState state)
+        private static ActivityReason GetActivityReason(ManagedMonitorState monitor, SystemState state, MonitorTimerState timerState)
         {
             if (IsSystemInputActive(monitor, state))
                 return ActivityReason.SystemInput;
@@ -250,6 +252,8 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
                 return ActivityReason.MousePosition;
             if (IsActiveWindowActive(monitor, state))
                 return ActivityReason.ActiveWindow;
+            if (IsContentChange(monitor, timerState))
+                return ActivityReason.ContentChange;
             return ActivityReason.None;
         }
 
@@ -283,6 +287,62 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
             return false;
         }
 
+        private static uint GetDownsampledScreenHash(Rect bounds, int skipPixels = 64)
+        {
+            System.Drawing.Rectangle drawingBounds = new System.Drawing.Rectangle(
+                (int)bounds.X,
+                (int)bounds.Y,
+                (int)bounds.Width,
+                (int)bounds.Height
+                );
+
+            using (Bitmap bmp = new Bitmap((int)bounds.Width, (int)bounds.Height, PixelFormat.Format32bppArgb))
+            {
+                using (Graphics g = Graphics.FromImage(bmp))
+                {
+                    g.CopyFromScreen(drawingBounds.Location, System.Drawing.Point.Empty, drawingBounds.Size);
+                }
+
+                BitmapData bmpData = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.ReadOnly, bmp.PixelFormat);
+                int bytes = Math.Abs(bmpData.Stride) * bmp.Height;
+                byte[] allPixels = new byte[bytes];
+                Marshal.Copy(bmpData.Scan0, allPixels, 0, bytes);
+                bmp.UnlockBits(bmpData);
+
+                uint hash = 2166136261;
+                const uint fnvPrime = 16777619;
+
+                int stride = Math.Abs(bmpData.Stride);
+
+                for (int y = 0; y < bmp.Height; y += skipPixels)
+                {
+                    for (int x = 0; x < bmp.Width; x += skipPixels)
+                    {
+                        int offset = (y * stride) + (x * 4);
+                        byte pixelValue = allPixels[offset];
+
+                        hash ^= pixelValue;
+                        hash *= fnvPrime;
+                    }
+                }
+
+                return hash;
+            }
+        }
+
+        private static bool IsContentChange(ManagedMonitorState monitor, MonitorTimerState timerState)
+        {
+            // If the monitor is in idle state and it gets black this would trigger content change, so it is only available to keep it active but not to activate it
+            if (monitor.Settings.IsActiveOnContentChange && timerState.CurrentState != MonitorStateMachine.Idle) { 
+                uint newHash = GetDownsampledScreenHash(monitor.Bounds);
+                if (newHash != monitor.lastHash) {
+                    monitor.lastHash = newHash;
+                    return true;
+                }
+            }
+            return false;
+        }
+
         // === System State Helpers ===
 
         /// <summary>
@@ -293,7 +353,7 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         {
             uint idleTime = GetSystemIdleTimeMilliseconds();
             NativeMethods.GetCursorPos(out var nativePoint);
-            Point cursorPosition = new(nativePoint.X, nativePoint.Y);
+            System.Windows.Point cursorPosition = new(nativePoint.X, nativePoint.Y);
             nint foregroundWindowHandle = NativeMethods.GetForegroundWindow();
             Rect windowRect = GetForegroundWindowRect(foregroundWindowHandle);
             return new SystemState(idleTime, cursorPosition, windowRect, foregroundWindowHandle);
@@ -353,6 +413,7 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
             public int DisplayNumber { get; set; }
             public MonitorSettings Settings { get; set; }
             public Rect Bounds { get; set; }
+            public uint lastHash { get; set; }
         }
 
         /// <summary>
@@ -370,11 +431,11 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         private readonly struct SystemState
         {
             public readonly uint IdleTimeMilliseconds;
-            public readonly Point CursorPosition;
+            public readonly System.Windows.Point CursorPosition;
             public readonly Rect ForegroundWindowRect;
             public readonly nint ForegroundWindowHandle;
 
-            public SystemState(uint idleTime, Point cursorPosition, Rect windowRect, nint windowHandle)
+            public SystemState(uint idleTime, System.Windows.Point cursorPosition, Rect windowRect, nint windowHandle)
             {
                 IdleTimeMilliseconds = idleTime;
                 CursorPosition = cursorPosition;

--- a/OLED-Sleeper/Features/MonitorInformation/Models/MonitorInfo.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Models/MonitorInfo.cs
@@ -42,5 +42,10 @@ namespace OLED_Sleeper.Features.MonitorInformation.Models
         /// Gets or sets a value indicating whether DDC/CI is supported by this monitor.
         /// </summary>
         public bool IsDdcCiSupported { get; set; }
+
+        /// <summary>
+        /// Gets or sets the bounding rectangle of the monitors working area (without taskbar) in coordinates.
+        /// </summary>
+        public Rect WorkingArea { get; set; }
     }
 }

--- a/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoManager.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoManager.cs
@@ -50,28 +50,52 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
         /// </summary>
         public void GetCurrentMonitorsAsync()
         {
+            List<MonitorInfo>? cached = null;
+
             lock (_lock)
             {
                 if (_cachedMonitors != null)
                 {
-                    MonitorListReady?.Invoke(this, _cachedMonitors);
-                    return;
+                    // capture current cache and invoke outside lock to avoid deadlocks
+                    cached = _cachedMonitors;
                 }
+
+                if (cached != null)
+                {
+                    // already have cached value, will notify outside lock
+                    // do not start a refresh
+                    goto NotifyCached;
+                }
+
                 if (_refreshTask != null)
                 {
                     Log.Debug("MonitorInfoManager: Refresh already in progress, skipping duplicate native call.");
                     return;
                 }
+
+                // Start a background refresh without holding the lock while doing IO/work
                 _refreshTask = Task.Run(() =>
                 {
-                    RefreshMonitorsInternal();
+                    var monitors = RefreshMonitorsInternal();
+                    List<MonitorInfo>? toNotify;
+
                     lock (_lock)
                     {
-                        MonitorListReady?.Invoke(this, _cachedMonitors);
+                        _cachedMonitors = monitors;
+                        toNotify = _cachedMonitors;
                         _refreshTask = null; // Allow future refreshes if needed
                     }
+
+                    var handlers = MonitorListReady;
+                    handlers?.Invoke(this, toNotify);
                 });
             }
+
+            return;
+
+        NotifyCached:
+            var cachedHandlers = MonitorListReady;
+            cachedHandlers?.Invoke(this, cached);
         }
 
         /// <summary>
@@ -83,12 +107,18 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
         {
             Task.Run(() =>
             {
+                Log.Information("Manual refresh requested. Re-scanning monitors.");
+                var monitors = RefreshMonitorsInternal();
+
+                List<MonitorInfo>? toNotify;
                 lock (_lock)
                 {
-                    Log.Information("Manual refresh requested. Re-scanning monitors.");
-                    RefreshMonitorsInternal();
-                    MonitorListReady?.Invoke(this, _cachedMonitors);
+                    _cachedMonitors = monitors;
+                    toNotify = _cachedMonitors;
                 }
+
+                var handlers = MonitorListReady;
+                handlers?.Invoke(this, toNotify);
             });
         }
 
@@ -122,11 +152,11 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
         /// <summary>
         /// Refreshes the monitor cache by retrieving basic info and enriching each monitor with DDC/CI support and hardware ID.
         /// </summary>
-        private void RefreshMonitorsInternal()
+        private List<MonitorInfo> RefreshMonitorsInternal()
         {
             var monitors = _monitorInfoProvider.GetAllMonitorsBasicInfo();
             EnrichMonitorInfoList(monitors);
-            _cachedMonitors = monitors;
+            return monitors;
         }
 
         #endregion Private Methods

--- a/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoProvider.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoProvider.cs
@@ -37,6 +37,11 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
                             mi.rcMonitor.top,
                             mi.rcMonitor.right - mi.rcMonitor.left,
                             mi.rcMonitor.bottom - mi.rcMonitor.top),
+                        WorkingArea = new Rect(
+                            mi.rcWork.left,
+                            mi.rcWork.top,
+                            mi.rcWork.right - mi.rcWork.left,
+                            mi.rcWork.bottom - mi.rcWork.top),
                         IsPrimary = (mi.dwFlags & 1) == 1,
                         Dpi = dpiX,
                         DisplayNumber = ParseDisplayNumber(mi.szDevice)

--- a/OLED-Sleeper/Features/UserSettings/Models/MonitorSettings.cs
+++ b/OLED-Sleeper/Features/UserSettings/Models/MonitorSettings.cs
@@ -54,6 +54,11 @@ namespace OLED_Sleeper.Features.UserSettings.Models
         public bool IsActiveOnActiveWindow { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets a value indicating whether the active window should reset idle state.
+        /// </summary>
+        public bool IsActiveOnContentChange { get; set; } = false;
+
+        /// <summary>
         /// Gets the idle timeout in milliseconds, based on <see cref="IdleValue"/> and <see cref="IdleUnit"/>.
         /// </summary>
         public int IdleTimeMilliseconds

--- a/OLED-Sleeper/UI/ViewModels/MonitorConfigurationViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MonitorConfigurationViewModel.cs
@@ -223,6 +223,26 @@ namespace OLED_Sleeper.UI.ViewModels
             }
         }
 
+
+        private bool _IsActiveOnContentChange;
+        private bool _initialIsActiveOnContentChange;
+
+        /// <summary>
+        /// Gets or sets whether the content of a monitor changed.
+        /// </summary>
+        public bool IsActiveOnContentChange
+        {
+            get => _IsActiveOnContentChange;
+            // --- Updated: Notifies error property when changed ---
+            set
+            {
+                _IsActiveOnContentChange = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(ActiveConditionsError));
+                UpdateDirtyState();
+            }
+        }
+
         #endregion Properties
 
         /// <summary>
@@ -261,7 +281,8 @@ namespace OLED_Sleeper.UI.ViewModels
                        SelectedTimeUnit != _initialSelectedTimeUnit ||
                        IsActiveOnInput != _initialIsActiveOnInput ||
                        IsActiveOnMousePosition != _initialIsActiveOnMousePosition ||
-                       IsActiveOnActiveWindow != _initialIsActiveOnActiveWindow;
+                       IsActiveOnActiveWindow != _initialIsActiveOnActiveWindow || 
+                       IsActiveOnContentChange != _initialIsActiveOnContentChange;
 
             OnPropertyChanged(nameof(IsDirty));
             OnDirtyStateChanged?.Invoke();
@@ -280,6 +301,7 @@ namespace OLED_Sleeper.UI.ViewModels
             _initialIsActiveOnInput = IsActiveOnInput;
             _initialIsActiveOnMousePosition = IsActiveOnMousePosition;
             _initialIsActiveOnActiveWindow = IsActiveOnActiveWindow;
+            _initialIsActiveOnContentChange = IsActiveOnContentChange;
             UpdateDirtyState();
         }
 
@@ -297,6 +319,7 @@ namespace OLED_Sleeper.UI.ViewModels
             IsActiveOnInput = settings.IsActiveOnInput;
             IsActiveOnMousePosition = settings.IsActiveOnMousePosition;
             IsActiveOnActiveWindow = settings.IsActiveOnActiveWindow;
+            IsActiveOnContentChange = settings.IsActiveOnContentChange;
         }
 
         /// <summary>
@@ -315,7 +338,8 @@ namespace OLED_Sleeper.UI.ViewModels
                 IdleUnit = SelectedTimeUnit,
                 IsActiveOnInput = IsActiveOnInput,
                 IsActiveOnMousePosition = IsActiveOnMousePosition,
-                IsActiveOnActiveWindow = IsActiveOnActiveWindow
+                IsActiveOnActiveWindow = IsActiveOnActiveWindow,
+                IsActiveOnContentChange = IsActiveOnContentChange
             };
         }
 
@@ -363,6 +387,7 @@ namespace OLED_Sleeper.UI.ViewModels
                     case nameof(IsActiveOnInput):
                     case nameof(IsActiveOnMousePosition):
                     case nameof(IsActiveOnActiveWindow):
+                    case nameof(IsActiveOnContentChange):
                         result = ValidateActiveConditions();
                         break;
 
@@ -391,7 +416,7 @@ namespace OLED_Sleeper.UI.ViewModels
         /// <returns>An error message if invalid, otherwise null.</returns>
         private string? ValidateActiveConditions()
         {
-            if (!IsActiveOnInput && !IsActiveOnMousePosition && !IsActiveOnActiveWindow)
+            if (!IsActiveOnInput && !IsActiveOnMousePosition && !IsActiveOnActiveWindow && !IsActiveOnContentChange)
                 return "At least one 'Consider Active When' option must be selected.";
             return null;
         }

--- a/OLED-Sleeper/UI/Views/MonitorConfigurationView.xaml
+++ b/OLED-Sleeper/UI/Views/MonitorConfigurationView.xaml
@@ -421,8 +421,10 @@
                         IsChecked="{Binding IsActiveOnMousePosition, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
                             <CheckBox Margin="0,0,0,8" Style="{StaticResource ModernCheckBox}" Content="Application is focused on this monitor"
                         IsChecked="{Binding IsActiveOnActiveWindow, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
-                            <CheckBox Margin="0,0,0,0" Style="{StaticResource ModernCheckBox}" Content="System has user input"
+                            <CheckBox Margin="0,0,0,8" Style="{StaticResource ModernCheckBox}" Content="System has user input"
                         IsChecked="{Binding IsActiveOnInput, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
+                            <CheckBox Margin="0,0,0,0" Style="{StaticResource ModernCheckBox}" Content="Monitor content changed (Experimental)"
+                        IsChecked="{Binding IsActiveOnContentChange, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
                         </StackPanel>
                     </StackPanel>
                 </Grid>


### PR DESCRIPTION
Idea:
Make hash of downsampled monitor content.
Hash code is from AI. I asked for something with low cpu usage...

Not sure about how many pixels should be observed. in my tests it worked so far.
-> Netflix (in window or fullscreen) avoided idle in my tests.
Performance impact needs to be checkt, but in Visual studio graph I did not see much change. (But i have not much experiance with checking performance impact in windows/VS)

One drawback: 
It is disabled to wake up the screen because the black screen layer would trigger to active and it can't see through black screen ;)
It would work with DDC/CI dimming... 