### PR TITLE
Fix blackout not applying to bottom of screen in negative coords

### DIFF
--- a/OLED-Sleeper/Features/MonitorBlackout/Services/MonitorBlackoutService.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Services/MonitorBlackoutService.cs
@@ -1,5 +1,7 @@
 ﻿using OLED_Sleeper.Features.MonitorBlackout.Services.Interfaces;
 using OLED_Sleeper.Native;
+using System;
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -27,13 +29,14 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
             {
                 if (_overlayWindows.ContainsKey(hardwareId)) return;
 
-                var overlay = CreateOverlayWindow(bounds);
+                var overlay = CreateOverlayWindow();
                 overlay.Show();
 
                 nint hwnd = new WindowInteropHelper(overlay).Handle;
                 if (hwnd != nint.Zero)
                 {
                     ApplyNoActivateStyle(hwnd);
+                    PositionOverlayToMonitor(hwnd, bounds);
                     _overlayHandles.Add(hwnd);
                 }
 
@@ -70,15 +73,11 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
         #region Private Helpers
 
         /// <summary>
-        /// Creates a new overlay window positioned and sized for the target monitor.
+        /// Creates a new overlay window.
         /// </summary>
-        /// <param name="bounds">The monitor bounds in physical screen coordinates.</param>
         /// <returns>A configured <see cref="Window"/> instance.</returns>
-        private static Window CreateOverlayWindow(Rect bounds)
-        {
-            var (scaleX, scaleY) = GetMonitorDpiScale(bounds);
-
-            return new Window
+        private static Window CreateOverlayWindow() =>
+            new()
             {
                 Cursor = System.Windows.Input.Cursors.None,
                 WindowStyle = WindowStyle.None,
@@ -87,40 +86,24 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
                 Background = Brushes.Black,
                 ShowInTaskbar = false,
                 Topmost = true,
-                WindowStartupLocation = WindowStartupLocation.Manual,
-
-                Left = bounds.Left / scaleX,
-                Top = bounds.Top / scaleY,
-                Width = bounds.Width / scaleX,
-                Height = bounds.Height / scaleY
+                WindowStartupLocation = WindowStartupLocation.Manual
             };
-        }
 
         /// <summary>
-        /// Retrieves the DPI scale factor for the monitor that contains the specified bounds.
+        /// Positions the overlay window to exactly cover the monitor using physical screen coordinates.
         /// </summary>
-        /// <param name="physicalBounds">The monitor bounds in physical screen coordinates.</param>
-        /// <returns>The scale factors for the X and Y axes.</returns>
-        private static (double scaleX, double scaleY) GetMonitorDpiScale(Rect physicalBounds)
+        /// <param name="hwnd">The window handle.</param>
+        /// <param name="bounds">The monitor bounds in physical screen coordinates.</param>
+        private static void PositionOverlayToMonitor(nint hwnd, Rect bounds)
         {
-            NativeMethods.Rect rect = new NativeMethods.Rect
-            {
-                left = (int)Math.Floor(physicalBounds.Left),
-                top = (int)Math.Floor(physicalBounds.Top),
-                right = (int)Math.Ceiling(physicalBounds.Right),
-                bottom = (int)Math.Ceiling(physicalBounds.Bottom)
-            };
-
-            IntPtr hMonitor = NativeMethods.MonitorFromRect(ref rect, NativeMethods.MONITOR_DEFAULTTONEAREST);
-            if (hMonitor == IntPtr.Zero)
-                return (1.0, 1.0);
-
-            uint dpiX = 96, dpiY = 96;
-            int hr = NativeMethods.GetDpiForMonitor(hMonitor, NativeMethods.MonitorDpiType.MDT_EFFECTIVE_DPI, out dpiX, out dpiY);
-
-            return hr == 0
-                ? (dpiX / 96.0, dpiY / 96.0)
-                : (1.0, 1.0);
+            NativeMethods.SetWindowPos(
+                hwnd,
+                NativeMethods.HWND_TOPMOST,
+                (int)bounds.Left,
+                (int)bounds.Top,
+                (int)bounds.Width,
+                (int)bounds.Height,
+                NativeMethods.SWP_NOACTIVATE);
         }
 
         /// <summary>

--- a/OLED-Sleeper/Native/NativeMethods.cs
+++ b/OLED-Sleeper/Native/NativeMethods.cs
@@ -175,6 +175,21 @@ namespace OLED_Sleeper.Native
         }
 
         /// <summary>
+        /// Places the window above all non-topmost windows.
+        /// </summary>
+        public static readonly IntPtr HWND_TOPMOST = new IntPtr(-1);
+
+        /// <summary>
+        /// Does not activate the window.
+        /// </summary>
+        public const uint SWP_NOACTIVATE = 0x0010;
+
+        /// <summary>
+        /// Use with <see cref="DwmGetWindowAttribute"/> to get the extended frame bounds rectangle.
+        /// </summary>
+        public const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
+
+        /// <summary>
         /// Delegate for monitor enumeration callback used by <see cref="EnumDisplayMonitors"/>.
         /// </summary>
         /// <param name="hMonitor">Handle to the display monitor.</param>
@@ -264,9 +279,10 @@ namespace OLED_Sleeper.Native
         public static extern IntPtr MonitorFromRect(ref Rect lprc, uint dwFlags);
 
         /// <summary>
-        /// Use with <see cref="DwmGetWindowAttribute"/> to get the extended frame bounds rectangle.
+        /// Places the window at the exact physical coordinates and size (bypasses WPF DIP issues).
         /// </summary>
-        public const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
 
         #endregion Monitor and Display Configuration
 


### PR DESCRIPTION
#### Description
The blackout overlay was not covering the full height of the secondary monitor, leaving a noticeable gap (~20px) at the bottom. This issue occurred specifically when the secondary monitor was positioned to the left of the primary (negative X coordinates), but worked correctly when placed on the right.

#### Root Cause
WPF's DIP-based positioning (`Left`/`Top`/`Width`/`Height`) has inconsistent behavior with negative virtual screen coordinates in mixed-DPI setups.

#### Fix
- Removed all DIP scaling logic from window creation.
- After `Show()`, use native `SetWindowPos` to position and size the overlay using the exact **physical** monitor bounds.
- This ensures pixel-perfect coverage regardless of monitor position (left or right) or DPI differences.