### PR TITLE
ISSUE-50 - Feature Request: Per-Monitor Media Detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,110 @@
+# Change log (working notes)
+
+## Build (quick reference)
+
+From the repository root:
+
+```bash
+dotnet build "\\tower.local\Repos\OLED-Sleeper\OLED-Sleeper.sln" -c Release
+```
+
+Optional: run tests with `dotnet test OLED-Sleeper.sln`.
+
+---
+
+**Important:** This file was **generated with AI assistance**. All content and all code changes described here **must be reviewed thoroughly** by a human before you rely on them for releases, compliance, or production use. Treat this document as informal notes, not an audited changelog.
+
+---
+
+## Session: monitor topology debounce & idle sync refactor
+
+These changes target flicker / black flashes when a secondary display wakes after idle “sleep” behavior, by reducing spurious topology syncs and avoiding tearing down the idle-detection loop on every sync.
+
+### 1. Topology debouncing & hysteresis (`MonitorStateWatcher`)
+
+- **File:** `OLED-Sleeper/Features/MonitorState/Services/MonitorStateWatcher.cs`
+- **Behavior:** A layout change is committed only after the same monitor topology (same device-name set and count) is observed on **`RequiredStableTopologyPolls` (3) consecutive polls** at the existing **2 second** poll interval (~6 seconds of stability before sync).
+- **Effect:** Brief enumeration glitches during display wake (e.g. monitor briefly missing from `EnumDisplayMonitors`) should no longer trigger immediate `SynchronizeMonitorStateCommand` storms.
+- **Initial startup:** The first sync from `MonitorListReady` is still **immediate** (not debounced).
+- **Snapshots:** Committed and pending topologies use **cloned** `MonitorInfo` lists so enrichment does not mutate stored state.
+
+### 2. Idle detection without stop/start on topology sync
+
+- **Files:**
+  - `OLED-Sleeper/Features/MonitorIdleDetection/Services/Interfaces/IMonitorIdleDetectionService.cs`
+  - `OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs`
+  - `OLED-Sleeper/Features/MonitorState/Handlers/SynchronizeMonitorStateCommandHandler.cs`
+- **New API:** `ApplyTopologyAndSettings(List<MonitorSettings>, IReadOnlyList<MonitorInfo>)` rebuilds managed monitors and resets per-monitor timer state **under the existing service lock** while the background idle loop keeps running.
+- **Refactor:** Shared `ApplyManagedMonitorsAndResetTimersUnlocked` used by both `UpdateSettings` (async cache path) and `ApplyTopologyAndSettings` (sync path with live enriched list from the watcher).
+- **`Start()`:** Now **idempotent** (guarded with `_lock` so only one loop is started). `Stop()` also uses `_lock` for consistency.
+- **Handler:** `SynchronizeMonitorStateCommandHandler` no longer calls `idleDetectionService.Stop()` or `UpdateSettings()` for topology sync; it updates cache, calls `ApplyTopologyAndSettings`, then `Start()`.
+
+### 3. Monitor info cache aligned with sync
+
+- **Files:**
+  - `OLED-Sleeper/Features/MonitorInformation/Services/Interfaces/IMonitorInfoManager.cs`
+  - `OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoManager.cs`
+- **New API:** `UpdateCachedMonitorsFromSnapshot(IReadOnlyList<MonitorInfo>)` copies enriched monitors into `_cachedMonitors` **without** raising `MonitorListReady`.
+- **Handler:** Invoked after topology sync so `GetCurrentMonitorsAsync()` consumers see a cache consistent with the committed topology.
+
+### 4. Dependency injection
+
+- **`SynchronizeMonitorStateCommandHandler`** now takes **`IMonitorInfoManager`** in addition to existing dependencies (primary constructor). `ServiceConfigurator` already registers `IMonitorInfoManager`; no registration change was required for a successful build in this session.
+
+---
+
+## Outstanding / uncommitted work (Git)
+
+**Note:** In the environment where this file was written, `git status` output was not captured reliably. **Run these locally** for the authoritative picture:
+
+```bash
+git status
+git diff
+```
+
+### Snapshot of other modified paths (from an earlier workspace `git status`)
+
+The following paths were already modified **before or outside** the topology/idle session above. They may still be dirty, may have been committed, or may overlap with the files listed in this document—**verify with `git status`**:
+
+| Path |
+|------|
+| `OLED-Sleeper.Tests/Features/MonitorBlackout/Handlers/HideBlackoutOverlayCommandHandlerTests.cs` |
+| `OLED-Sleeper/Features/MonitorBehavior/Commands/RestoreMonitorStateCommand.cs` |
+| `OLED-Sleeper/Features/MonitorBlackout/Handlers/ApplyBlackoutOverlayCommandHandler.cs` |
+| `OLED-Sleeper/Features/MonitorBlackout/Handlers/HideBlackoutOverlayCommandHandler.cs` |
+| `OLED-Sleeper/Features/MonitorDimming/Handlers/ApplyDimCommandHandler.cs` |
+| `OLED-Sleeper/Features/MonitorDimming/Handlers/ApplyUndimCommandHandler.cs` |
+| `OLED-Sleeper/Features/MonitorDimming/Services/Interfaces/IMonitorDimmingService.cs` |
+| `OLED-Sleeper/Features/MonitorDimming/Services/MonitorDimmingService.cs` |
+| `OLED-Sleeper/Features/MonitorIdleDetection/Models/ActivityReason.cs` |
+| `OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs` *(also edited in the session above)* |
+| `OLED-Sleeper/Features/MonitorInformation/Services/Interfaces/IMonitorInfoManager.cs` *(also edited in the session above)* |
+| `OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoManager.cs` *(also edited in the session above)* |
+| `OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoProvider.cs` |
+| `OLED-Sleeper/Features/MonitorState/Handlers/SynchronizeMonitorStateCommandHandler.cs` *(also edited in the session above)* |
+| `OLED-Sleeper/Features/MonitorState/Services/MonitorStateWatcher.cs` *(also edited in the session above)* |
+| `OLED-Sleeper/Native/NativeMethods.cs` |
+| `OLED-Sleeper/UI/Services/Interfaces/IWorkspaceService.cs` |
+| `OLED-Sleeper/UI/Services/WorkspaceService.cs` |
+| `OLED-Sleeper/UI/ViewModels/MonitorConfigurationViewModel.cs` |
+| `OLED-Sleeper/UI/ViewModels/MonitorLayoutViewModel.cs` |
+| `OLED-Sleeper/UI/Views/MonitorConfigurationView.xaml` |
+
+### Files touched specifically for topology debounce + idle sync (this session)
+
+- `OLED-Sleeper/Features/MonitorIdleDetection/Services/Interfaces/IMonitorIdleDetectionService.cs`
+- `OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs`
+- `OLED-Sleeper/Features/MonitorInformation/Services/Interfaces/IMonitorInfoManager.cs`
+- `OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoManager.cs`
+- `OLED-Sleeper/Features/MonitorState/Services/MonitorStateWatcher.cs`
+- `OLED-Sleeper/Features/MonitorState/Handlers/SynchronizeMonitorStateCommandHandler.cs`
+- `CHANGES.md` (this file)
+
+---
+
+## Review checklist (human)
+
+- [ ] Confirm debounce count (`RequiredStableTopologyPolls = 3`) is acceptable for your hardware (too high = slow reaction to real unplug; too low = still noisy on wake).
+- [ ] Exercise: secondary monitor wake after OLED-Sleeper idle sleep, multi-monitor hotplug, and settings changes (still using `UpdateSettings` path).
+- [ ] Confirm no duplicate idle loops or regressions around app shutdown (`Stop()` still cancels the loop once).
+- [ ] Run full test suite and manual UI pass; re-run `git diff` and code review on every file in the working tree.

--- a/OLED-Sleeper.Tests/Features/MonitorBlackout/Handlers/HideBlackoutOverlayCommandHandlerTests.cs
+++ b/OLED-Sleeper.Tests/Features/MonitorBlackout/Handlers/HideBlackoutOverlayCommandHandlerTests.cs
@@ -52,7 +52,7 @@ namespace OLED_Sleeper.Tests.Features.MonitorBlackout.Handlers
         }
 
         [Fact]
-        public async Task HandleAsync_WithNullHardwareId_DoesNotThrow()
+        public async Task HandleAsync_WithNullHardwareId_DoesNotThrowAndSkipsService()
         {
             // Arrange
             var command = new HideBlackoutOverlayCommand { HardwareId = null };
@@ -62,7 +62,7 @@ namespace OLED_Sleeper.Tests.Features.MonitorBlackout.Handlers
 
             // Assert
             Assert.Null(exception);
-            _monitorBlackoutServiceMock.Verify(x => x.HideBlackoutOverlayAsync(It.IsAny<string>()), Times.Once);
+            _monitorBlackoutServiceMock.Verify(x => x.HideBlackoutOverlayAsync(It.IsAny<string>()), Times.Never);
         }
     }
 }

--- a/OLED-Sleeper/Features/MonitorBehavior/Commands/RestoreMonitorStateCommand.cs
+++ b/OLED-Sleeper/Features/MonitorBehavior/Commands/RestoreMonitorStateCommand.cs
@@ -11,6 +11,6 @@ namespace OLED_Sleeper.Features.MonitorBehavior.Commands
         /// <summary>
         /// Gets or sets the unique hardware ID of the monitor to be restored.
         /// </summary>
-        public string HardwareId { get; set; }
+        public required string HardwareId { get; set; }
     }
 }

--- a/OLED-Sleeper/Features/MonitorBlackout/Handlers/ApplyBlackoutOverlayCommandHandler.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Handlers/ApplyBlackoutOverlayCommandHandler.cs
@@ -49,16 +49,28 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Handlers
                 Log.Information("Executing ApplyBlackoutCommand for monitor {HardwareId}.", command.HardwareId);
 
                 var monitorInfo = await GetMonitorInfoAsync(command.HardwareId);
+                if (monitorInfo == null)
+                {
+                    Log.Warning("ApplyBlackoutOverlayCommand: no monitor found for HardwareId {HardwareId}.", command.HardwareId);
+                    return;
+                }
+
+                var hardwareId = monitorInfo.HardwareId ?? command.HardwareId;
+                if (string.IsNullOrEmpty(hardwareId))
+                {
+                    Log.Warning("ApplyBlackoutOverlayCommand: could not resolve hardware id for monitor.");
+                    return;
+                }
 
                 // Task 1: Show the software blackout overlay.
                 // We start this task but don't await it immediately.
-                var showOverlayTask = _monitorBlackoutService.ShowBlackoutOverlayAsync(monitorInfo.HardwareId, monitorInfo.Bounds);
+                var showOverlayTask = _monitorBlackoutService.ShowBlackoutOverlayAsync(hardwareId, monitorInfo.Bounds);
 
                 // Task 2: If supported, also set the hardware brightness to 0 via DDC/CI.
                 if (monitorInfo.IsDdcCiSupported)
                 {
-                    Log.Information("Monitor {HardwareId} supports DDC/CI. Setting brightness to 0 for blackout.", monitorInfo.HardwareId);
-                    var dimTask = _monitorDimmingService.DimMonitorAsync(monitorInfo.HardwareId, 0);
+                    Log.Information("Monitor {HardwareId} supports DDC/CI. Setting brightness to 0 for blackout.", hardwareId);
+                    var dimTask = _monitorDimmingService.DimMonitorAsync(hardwareId, 0);
 
                     // Await both the overlay and dimming tasks to complete concurrently.
                     await Task.WhenAll(showOverlayTask, dimTask);

--- a/OLED-Sleeper/Features/MonitorBlackout/Handlers/HideBlackoutOverlayCommandHandler.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Handlers/HideBlackoutOverlayCommandHandler.cs
@@ -32,6 +32,12 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Handlers
         {
             try
             {
+                if (string.IsNullOrEmpty(command.HardwareId))
+                {
+                    Log.Warning("HideBlackoutOverlayCommand missing HardwareId; skipping.");
+                    return;
+                }
+
                 Log.Information("Executing HideBlackoutOverlayCommand for monitor {HardwareId}.", command.HardwareId);
                 await _monitorBlackoutService.HideBlackoutOverlayAsync(command.HardwareId);
             }

--- a/OLED-Sleeper/Features/MonitorDimming/Handlers/ApplyDimCommandHandler.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Handlers/ApplyDimCommandHandler.cs
@@ -32,6 +32,12 @@ namespace OLED_Sleeper.Features.MonitorDimming.Handlers
         {
             try
             {
+                if (string.IsNullOrEmpty(command.HardwareId))
+                {
+                    Log.Warning("ApplyDimCommand missing HardwareId; skipping.");
+                    return;
+                }
+
                 Log.Information("Executing ApplyDimCommand for monitor {HardwareId} to level {DimLevel}.", command.HardwareId, command.DimLevel);
                 await _monitorDimmingService.DimMonitorAsync(command.HardwareId, command.DimLevel);
             }

--- a/OLED-Sleeper/Features/MonitorDimming/Handlers/ApplyUndimCommandHandler.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Handlers/ApplyUndimCommandHandler.cs
@@ -32,6 +32,12 @@ namespace OLED_Sleeper.Features.MonitorDimming.Handlers
         {
             try
             {
+                if (string.IsNullOrEmpty(command.HardwareId))
+                {
+                    Log.Warning("ApplyUndimCommand missing HardwareId; skipping.");
+                    return;
+                }
+
                 Log.Information("Executing UndimMonitorCommand for monitor {HardwareId}.", command.HardwareId);
                 await _monitorDimmingService.UndimMonitorAsync(command.HardwareId);
             }

--- a/OLED-Sleeper/Features/MonitorDimming/Services/Interfaces/IMonitorDimmingService.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/Interfaces/IMonitorDimmingService.cs
@@ -11,7 +11,7 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services.Interfaces
         /// <param name="hardwareId">The unique hardware ID of the monitor.</param>
         /// <param name="dimLevel">The brightness level to set (0-100).</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        Task DimMonitorAsync(string? hardwareId, int dimLevel);
+        Task DimMonitorAsync(string hardwareId, int dimLevel);
 
         /// <summary>
         /// Restores the specified monitor to its original brightness asynchronously.

--- a/OLED-Sleeper/Features/MonitorDimming/Services/MonitorDimmingService.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/MonitorDimmingService.cs
@@ -72,7 +72,7 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
         {
             var tcs = new TaskCompletionSource<IReadOnlyList<MonitorInfo>>();
 
-            EventHandler<IReadOnlyList<MonitorInfo>> handler = null;
+            EventHandler<IReadOnlyList<MonitorInfo>>? handler = null;
             handler = (sender, monitors) =>
             {
                 // Unsubscribe to prevent memory leaks.

--- a/OLED-Sleeper/Features/MonitorIdleDetection/Models/ActivityReason.cs
+++ b/OLED-Sleeper/Features/MonitorIdleDetection/Models/ActivityReason.cs
@@ -22,6 +22,11 @@
         ActiveWindow,
 
         /// <summary>
+        /// A visible application window is present on this monitor even if it is not the foreground window.
+        /// </summary>
+        VisibleWindow,
+
+        /// <summary>
         /// System input (keyboard or mouse activity) was detected.
         /// </summary>
         SystemInput

--- a/OLED-Sleeper/Features/MonitorIdleDetection/Services/Interfaces/IMonitorIdleDetectionService.cs
+++ b/OLED-Sleeper/Features/MonitorIdleDetection/Services/Interfaces/IMonitorIdleDetectionService.cs
@@ -1,3 +1,4 @@
+using OLED_Sleeper.Features.MonitorInformation.Models;
 using OLED_Sleeper.Features.UserSettings.Models;
 
 namespace OLED_Sleeper.Features.MonitorIdleDetection.Services.Interfaces
@@ -9,7 +10,7 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services.Interfaces
     public interface IMonitorIdleDetectionService
     {
         /// <summary>
-        /// Starts the idle detection service and begins monitoring.
+        /// Starts the idle detection service and begins monitoring. Safe to call multiple times; only the first call starts the loop.
         /// </summary>
         void Start();
 
@@ -23,5 +24,13 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services.Interfaces
         /// </summary>
         /// <param name="monitorSettings">The list of monitor settings to manage.</param>
         void UpdateSettings(List<MonitorSettings> monitorSettings);
+
+        /// <summary>
+        /// Rebuilds managed monitors and resets per-monitor timers from persisted settings and an already-enriched live topology,
+        /// without stopping the idle loop.
+        /// </summary>
+        /// <param name="monitorSettings">Full persisted settings list (managed flags are respected).</param>
+        /// <param name="activeEnrichedMonitors">Current monitors with hardware IDs and DDC flags populated.</param>
+        void ApplyTopologyAndSettings(List<MonitorSettings> monitorSettings, IReadOnlyList<MonitorInfo> activeEnrichedMonitors);
     }
 }

--- a/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
+++ b/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
@@ -1,5 +1,6 @@
 ﻿using OLED_Sleeper.Core.Interfaces;
 using OLED_Sleeper.Features.MonitorBehavior.Commands;
+using OLED_Sleeper.Features.MonitorBlackout.Services.Interfaces;
 using OLED_Sleeper.Features.MonitorIdleDetection.Models;
 using OLED_Sleeper.Features.MonitorIdleDetection.Services.Interfaces;
 using OLED_Sleeper.Features.MonitorInformation.Models;
@@ -8,6 +9,7 @@ using OLED_Sleeper.Features.UserSettings.Models;
 using OLED_Sleeper.Native;
 using Serilog;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Windows;
 
 namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
@@ -27,10 +29,15 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         private readonly IMediator _mediator;
 
         private readonly IMonitorInfoManager _monitorManager;
-        private CancellationTokenSource _cancellationTokenSource;
+        private readonly IMonitorBlackoutService _monitorBlackoutService;
+        private CancellationTokenSource? _cancellationTokenSource;
         private List<ManagedMonitorState> _managedMonitors = new();
         private readonly object _lock = new();
         private readonly Dictionary<string, MonitorTimerState> _monitorStates = new();
+        private static readonly HashSet<string> EmptyHardwareIdSet = new(StringComparer.Ordinal);
+        private HashSet<string> _cachedVisibleWindowHardwareIds = new(StringComparer.Ordinal);
+        private DateTime _visibleWindowCacheUtc = DateTime.MinValue;
+        private const int VisibleWindowScanIntervalMs = 400;
 
         // === Construction ===
 
@@ -39,10 +46,15 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         /// </summary>
         /// <param name="monitorManager">Service for monitor information.</param>
         /// <param name="mediator">Mediator for dispatching monitor behavior commands.</param>
-        public MonitorIdleDetectionService(IMonitorInfoManager monitorManager, IMediator mediator)
+        /// <param name="monitorBlackoutService">Service used to ignore blackout overlay windows when enumerating visible windows.</param>
+        public MonitorIdleDetectionService(
+            IMonitorInfoManager monitorManager,
+            IMediator mediator,
+            IMonitorBlackoutService monitorBlackoutService)
         {
             _monitorManager = monitorManager;
             _mediator = mediator;
+            _monitorBlackoutService = monitorBlackoutService;
         }
 
         // === Service Lifecycle ===
@@ -52,8 +64,16 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         /// </summary>
         public void Start()
         {
-            _cancellationTokenSource = new CancellationTokenSource();
-            Task.Run(() => IdleCheckLoop(_cancellationTokenSource.Token));
+            lock (_lock)
+            {
+                if (_cancellationTokenSource != null)
+                    return;
+
+                _cancellationTokenSource = new CancellationTokenSource();
+                var token = _cancellationTokenSource.Token;
+                _ = Task.Run(() => IdleCheckLoop(token));
+            }
+
             Log.Information("MonitorIdleDetectionService started.");
         }
 
@@ -62,8 +82,13 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         /// </summary>
         public void Stop()
         {
-            _cancellationTokenSource?.Cancel();
-            _cancellationTokenSource?.Dispose();
+            lock (_lock)
+            {
+                _cancellationTokenSource?.Cancel();
+                _cancellationTokenSource?.Dispose();
+                _cancellationTokenSource = null;
+            }
+
             Log.Information("MonitorIdleDetectionService stopped.");
         }
 
@@ -79,28 +104,58 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
             {
                 _monitorManager.MonitorListReady -= OnMonitorsReady;
 
+                int count;
                 lock (_lock)
                 {
-                    _managedMonitors = (from setting in activeSettings
-                                        join monitorInfo in allMonitors on setting.HardwareId equals monitorInfo.HardwareId
-                                        select new ManagedMonitorState
-                                        {
-                                            Settings = setting,
-                                            Bounds = monitorInfo.Bounds,
-                                            DisplayNumber = monitorInfo.DisplayNumber
-                                        }).ToList();
-
-                    _monitorStates.Clear();
-                    foreach (var monitor in _managedMonitors)
-                    {
-                        _monitorStates[monitor.Settings.HardwareId] = new MonitorTimerState();
-                    }
+                    ApplyManagedMonitorsAndResetTimersUnlocked(activeSettings, allMonitors);
+                    count = _managedMonitors.Count;
                 }
-                Log.Information("MonitorIdleDetectionService settings updated. Now tracking {Count} monitors.", _managedMonitors.Count);
+
+                Log.Information("MonitorIdleDetectionService settings updated. Now tracking {Count} monitors.", count);
             }
 
             _monitorManager.MonitorListReady += OnMonitorsReady;
             _monitorManager.GetCurrentMonitorsAsync();
+        }
+
+        /// <inheritdoc />
+        public void ApplyTopologyAndSettings(List<MonitorSettings> monitorSettings, IReadOnlyList<MonitorInfo> activeEnrichedMonitors)
+        {
+            var activeSettings = monitorSettings.Where(s => s.IsManaged).ToList();
+
+            int count;
+            lock (_lock)
+            {
+                ApplyManagedMonitorsAndResetTimersUnlocked(activeSettings, activeEnrichedMonitors);
+                count = _managedMonitors.Count;
+            }
+
+            Log.Information("MonitorIdleDetectionService topology applied. Now tracking {Count} monitors.", count);
+        }
+
+        /// <summary>
+        /// Rebuilds managed monitors and timer state. Caller must hold <c>_lock</c>.
+        /// </summary>
+        private void ApplyManagedMonitorsAndResetTimersUnlocked(
+            List<MonitorSettings> activeSettings,
+            IReadOnlyList<MonitorInfo> allMonitors)
+        {
+            _managedMonitors = (from setting in activeSettings
+                                join monitorInfo in allMonitors on setting.HardwareId equals monitorInfo.HardwareId
+                                select new ManagedMonitorState
+                                {
+                                    Settings = setting,
+                                    Bounds = monitorInfo.Bounds,
+                                    DisplayNumber = monitorInfo.DisplayNumber
+                                }).ToList();
+
+            _monitorStates.Clear();
+            foreach (var monitor in _managedMonitors)
+            {
+                _monitorStates[monitor.Settings.HardwareId] = new MonitorTimerState();
+            }
+
+            _visibleWindowCacheUtc = DateTime.MinValue;
         }
 
         // === Idle Detection Loop ===
@@ -130,7 +185,14 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         /// </summary>
         private void ProcessMonitors()
         {
-            var systemState = GetSystemState();
+            List<ManagedMonitorState> snapshot;
+            lock (_lock)
+            {
+                snapshot = _managedMonitors.ToList();
+            }
+
+            var visibleOnHardwareIds = GetVisibleWindowHardwareIdsSnapshot(snapshot);
+            var systemState = GetSystemState(visibleOnHardwareIds);
 
             lock (_lock)
             {
@@ -250,6 +312,8 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
                 return ActivityReason.MousePosition;
             if (IsActiveWindowActive(monitor, state))
                 return ActivityReason.ActiveWindow;
+            if (IsVisibleWindowActive(monitor, state))
+                return ActivityReason.VisibleWindow;
             return ActivityReason.None;
         }
 
@@ -283,20 +347,201 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
             return false;
         }
 
+        /// <summary>
+        /// Checks whether a visible (non-foreground) window on this monitor should count as activity.
+        /// </summary>
+        private static bool IsVisibleWindowActive(ManagedMonitorState monitor, SystemState state)
+        {
+            return monitor.Settings.IsActiveOnVisibleWindows
+                   && state.HardwareIdsWithVisibleWindows.Contains(monitor.Settings.HardwareId);
+        }
+
+        /// <summary>
+        /// Returns cached or freshly enumerated hardware IDs for monitors that have a qualifying visible window.
+        /// </summary>
+        private HashSet<string> GetVisibleWindowHardwareIdsSnapshot(IReadOnlyList<ManagedMonitorState> monitors)
+        {
+            if (!monitors.Any(m => m.Settings.IsActiveOnVisibleWindows))
+                return EmptyHardwareIdSet;
+
+            var now = DateTime.UtcNow;
+            if ((now - _visibleWindowCacheUtc).TotalMilliseconds < VisibleWindowScanIntervalMs)
+                return _cachedVisibleWindowHardwareIds;
+
+            _visibleWindowCacheUtc = now;
+            _cachedVisibleWindowHardwareIds = ComputeHardwareIdsWithVisibleAppWindows(monitors);
+            return _cachedVisibleWindowHardwareIds;
+        }
+
+        /// <summary>
+        /// Enumerates top-level windows and maps monitors (with the option enabled) that intersect a visible, non-shell window.
+        /// </summary>
+        private HashSet<string> ComputeHardwareIdsWithVisibleAppWindows(IReadOnlyList<ManagedMonitorState> monitors)
+        {
+            var result = new HashSet<string>(StringComparer.Ordinal);
+            var targets = monitors.Where(m => m.Settings.IsActiveOnVisibleWindows).ToList();
+            if (targets.Count == 0)
+                return result;
+
+            var distinctHardwareIds = targets.Select(m => m.Settings.HardwareId).Distinct(StringComparer.Ordinal).ToList();
+            var monitorHandleByHardwareId = new Dictionary<string, nint>(StringComparer.Ordinal);
+            foreach (var id in distinctHardwareIds)
+            {
+                var sample = targets.First(m => m.Settings.HardwareId == id);
+                monitorHandleByHardwareId[id] = GetMonitorHandleFromBounds(sample.Bounds);
+            }
+
+            nint shellWindow = NativeMethods.GetShellWindow();
+
+            NativeMethods.EnumWindows((hWnd, _) =>
+            {
+                if (result.Count >= distinctHardwareIds.Count)
+                    return false;
+
+                nint hwnd = hWnd;
+                if (!NativeMethods.IsWindow(hwnd) || !NativeMethods.IsWindowVisible(hwnd) || NativeMethods.IsIconic(hwnd))
+                    return true;
+                if (hwnd == shellWindow || _monitorBlackoutService.IsOverlayWindow(hwnd))
+                    return true;
+                if (IsWindowCloaked(hwnd))
+                    return true;
+
+                var className = GetWindowClassName(hwnd);
+                if (IsShellDesktopWindowClass(className))
+                    return true;
+
+                Rect windowBounds = GetWindowScreenBoundsForVisibleScan(hwnd);
+                if (windowBounds.IsEmpty || windowBounds.Width <= 0 || windowBounds.Height <= 0)
+                    return true;
+
+                nint windowMonitor = (nint)NativeMethods.MonitorFromWindow((IntPtr)hwnd, NativeMethods.MONITOR_DEFAULTTONULL);
+
+                foreach (var m in targets)
+                {
+                    if (result.Contains(m.Settings.HardwareId))
+                        continue;
+                    if (!monitorHandleByHardwareId.TryGetValue(m.Settings.HardwareId, out nint targetMonitor))
+                        continue;
+
+                    bool anchoredOnMonitor = windowMonitor != nint.Zero && windowMonitor == targetMonitor;
+                    bool rectsOverlap = MonitorIntersectsWindow(m.Bounds, windowBounds);
+                    if (!(anchoredOnMonitor || rectsOverlap))
+                        continue;
+
+                    // Require meaningful coverage on this monitor so shadows, DWM helpers, or huge rects
+                    // that only clip a sliver of the display do not block blackout.
+                    if (!HasSignificantVisibleOverlap(m.Bounds, windowBounds))
+                        continue;
+
+                    result.Add(m.Settings.HardwareId);
+                }
+
+                return true;
+            }, IntPtr.Zero);
+
+            return result;
+        }
+
+        private static nint GetMonitorHandleFromBounds(Rect bounds)
+        {
+            var nativeRect = new NativeMethods.Rect
+            {
+                left = (int)Math.Floor(bounds.Left),
+                top = (int)Math.Floor(bounds.Top),
+                right = (int)Math.Ceiling(bounds.Right),
+                bottom = (int)Math.Ceiling(bounds.Bottom)
+            };
+            return (nint)NativeMethods.MonitorFromRect(ref nativeRect, NativeMethods.MONITOR_DEFAULTTONEAREST);
+        }
+
+        /// <summary>
+        /// Window bounds for "is something covering this monitor" checks.
+        /// Uses <see cref="NativeMethods.GetWindowRect"/> first because DWM extended frame bounds are often wrong or empty for fullscreen and GPU-presented windows.
+        /// </summary>
+        private static Rect GetWindowScreenBoundsForVisibleScan(nint hwnd)
+        {
+            if (NativeMethods.GetWindowRect(hwnd, out var nativeRect))
+            {
+                var r = nativeRect.ToWindowsRect();
+                if (r.Width > 0 && r.Height > 0)
+                    return r;
+            }
+
+            if (NativeMethods.DwmGetWindowAttribute(hwnd, NativeMethods.DWMWA_EXTENDED_FRAME_BOUNDS, out nativeRect, Marshal.SizeOf(typeof(NativeMethods.Rect))) == 0)
+            {
+                var r = nativeRect.ToWindowsRect();
+                if (r.Width > 0 && r.Height > 0)
+                    return r;
+            }
+
+            return Rect.Empty;
+        }
+
+        private static bool MonitorIntersectsWindow(Rect monitorBounds, Rect windowBounds)
+        {
+            Rect intersection = Rect.Intersect(monitorBounds, windowBounds);
+            return !intersection.IsEmpty && intersection.Width > 0 && intersection.Height > 0;
+        }
+
+        /// <summary>
+        /// True when the window covers enough of the monitor to count as real content (not a shadow, sliver, or stray overlap from another display).
+        /// </summary>
+        private static bool HasSignificantVisibleOverlap(Rect monitorBounds, Rect windowBounds)
+        {
+            Rect intersection = Rect.Intersect(monitorBounds, windowBounds);
+            if (intersection.IsEmpty || intersection.Width <= 0 || intersection.Height <= 0)
+                return false;
+
+            double intersectionPixels = intersection.Width * intersection.Height;
+            double monitorPixels = monitorBounds.Width * monitorBounds.Height;
+            if (monitorPixels <= 0)
+                return false;
+
+            const double minFractionOfMonitor = 0.015;
+            const double absoluteMinPixels = 40_000;
+            double threshold = Math.Max(absoluteMinPixels, monitorPixels * minFractionOfMonitor);
+            return intersectionPixels >= threshold;
+        }
+
+        private static string GetWindowClassName(nint hwnd)
+        {
+            var sb = new StringBuilder(256);
+            return NativeMethods.GetClassName(hwnd, sb, sb.Capacity) > 0 ? sb.ToString() : string.Empty;
+        }
+
+        private static bool IsShellDesktopWindowClass(string className) =>
+            className.Equals("Progman", StringComparison.OrdinalIgnoreCase)
+            || className.Equals("WorkerW", StringComparison.OrdinalIgnoreCase)
+            || className.Equals("Shell_TrayWnd", StringComparison.OrdinalIgnoreCase)
+            || className.Equals("Shell_SecondaryTrayWnd", StringComparison.OrdinalIgnoreCase)
+            || className.Equals("NotifyIconOverflowWindow", StringComparison.OrdinalIgnoreCase)
+            || className.Equals("DummyDWMListenerWindow", StringComparison.OrdinalIgnoreCase)
+            || className.Equals("XamlExplorerHostIslandWindow", StringComparison.OrdinalIgnoreCase)
+            || className.Equals("SysShadow", StringComparison.OrdinalIgnoreCase)
+            || className.Equals("Windows.UI.Composition.DesktopWindowContentBridge", StringComparison.OrdinalIgnoreCase);
+
+        private static bool IsWindowCloaked(nint hwnd)
+        {
+            if (NativeMethods.DwmGetWindowAttributeInt(hwnd, NativeMethods.DWMWA_CLOAKED, out int cloaked, sizeof(int)) != 0)
+                return false;
+            return cloaked != 0;
+        }
+
         // === System State Helpers ===
 
         /// <summary>
         /// Gathers all required system-wide state information at once.
         /// </summary>
+        /// <param name="hardwareIdsWithVisibleWindows">Monitors that currently have a qualifying visible window.</param>
         /// <returns>System state snapshot.</returns>
-        private static SystemState GetSystemState()
+        private static SystemState GetSystemState(HashSet<string> hardwareIdsWithVisibleWindows)
         {
             uint idleTime = GetSystemIdleTimeMilliseconds();
             NativeMethods.GetCursorPos(out var nativePoint);
             Point cursorPosition = new(nativePoint.X, nativePoint.Y);
             nint foregroundWindowHandle = NativeMethods.GetForegroundWindow();
             Rect windowRect = GetForegroundWindowRect(foregroundWindowHandle);
-            return new SystemState(idleTime, cursorPosition, windowRect, foregroundWindowHandle);
+            return new SystemState(idleTime, cursorPosition, windowRect, foregroundWindowHandle, hardwareIdsWithVisibleWindows);
         }
 
         /// <summary>
@@ -351,7 +596,7 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         private class ManagedMonitorState
         {
             public int DisplayNumber { get; set; }
-            public MonitorSettings Settings { get; set; }
+            public required MonitorSettings Settings { get; set; }
             public Rect Bounds { get; set; }
         }
 
@@ -373,13 +618,20 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
             public readonly Point CursorPosition;
             public readonly Rect ForegroundWindowRect;
             public readonly nint ForegroundWindowHandle;
+            public readonly HashSet<string> HardwareIdsWithVisibleWindows;
 
-            public SystemState(uint idleTime, Point cursorPosition, Rect windowRect, nint windowHandle)
+            public SystemState(
+                uint idleTime,
+                Point cursorPosition,
+                Rect windowRect,
+                nint windowHandle,
+                HashSet<string> hardwareIdsWithVisibleWindows)
             {
                 IdleTimeMilliseconds = idleTime;
                 CursorPosition = cursorPosition;
                 ForegroundWindowRect = windowRect;
                 ForegroundWindowHandle = windowHandle;
+                HardwareIdsWithVisibleWindows = hardwareIdsWithVisibleWindows;
             }
         }
     }

--- a/OLED-Sleeper/Features/MonitorInformation/Services/Interfaces/IMonitorInfoManager.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/Interfaces/IMonitorInfoManager.cs
@@ -17,7 +17,7 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services.Interfaces
         /// <summary>
         /// Raised when the monitor list has been retrieved and enriched.
         /// </summary>
-        event EventHandler<IReadOnlyList<MonitorInfo>> MonitorListReady;
+        event EventHandler<IReadOnlyList<MonitorInfo>>? MonitorListReady;
 
         /// <summary>
         /// Forces a refresh of the monitor list from the system asynchronously.
@@ -37,5 +37,11 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services.Interfaces
         /// </summary>
         /// <param name="monitors">The list of monitors to enrich.</param>
         void EnrichMonitorInfoList(List<MonitorInfo> monitors);
+
+        /// <summary>
+        /// Replaces the cached monitor list with a snapshot (typically after a topology sync). Does not raise <see cref="MonitorListReady"/>.
+        /// </summary>
+        /// <param name="monitors">Enriched monitors to store; values are copied defensively.</param>
+        void UpdateCachedMonitorsFromSnapshot(IReadOnlyList<MonitorInfo> monitors);
     }
 }

--- a/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoManager.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoManager.cs
@@ -13,7 +13,7 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
         #region Fields
 
         private readonly IMonitorInfoProvider _monitorInfoProvider;
-        private List<MonitorInfo> _cachedMonitors;
+        private List<MonitorInfo>? _cachedMonitors;
         private readonly object _lock = new object();
         private Task? _refreshTask;
 
@@ -24,7 +24,7 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
         /// <summary>
         /// Raised when the monitor list has been retrieved and enriched.
         /// </summary>
-        public event EventHandler<IReadOnlyList<MonitorInfo>> MonitorListReady;
+        public event EventHandler<IReadOnlyList<MonitorInfo>>? MonitorListReady;
 
         #endregion Events
 
@@ -67,7 +67,7 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
                     RefreshMonitorsInternal();
                     lock (_lock)
                     {
-                        MonitorListReady?.Invoke(this, _cachedMonitors);
+                        MonitorListReady?.Invoke(this, _cachedMonitors!);
                         _refreshTask = null; // Allow future refreshes if needed
                     }
                 });
@@ -87,7 +87,7 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
                 {
                     Log.Information("Manual refresh requested. Re-scanning monitors.");
                     RefreshMonitorsInternal();
-                    MonitorListReady?.Invoke(this, _cachedMonitors);
+                    MonitorListReady?.Invoke(this, _cachedMonitors!);
                 }
             });
         }
@@ -105,13 +105,33 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
         /// Enriches a list of MonitorInfo objects with DDC/CI support and hardware ID.
         /// </summary>
         /// <param name="monitors">The list of monitors to enrich.</param>
-        public void EnrichMonitorInfoList(List<MonitorInfo>? monitors)
+        public void EnrichMonitorInfoList(List<MonitorInfo> monitors)
         {
             if (monitors == null) return;
             foreach (var monitor in monitors)
             {
                 monitor.IsDdcCiSupported = _monitorInfoProvider.GetDdcCiSupport(monitor);
                 monitor.HardwareId = _monitorInfoProvider.GetHardwareId(monitor);
+            }
+        }
+
+        /// <inheritdoc />
+        public void UpdateCachedMonitorsFromSnapshot(IReadOnlyList<MonitorInfo> monitors)
+        {
+            var copy = monitors.Select(m => new MonitorInfo
+            {
+                DeviceName = m.DeviceName,
+                HardwareId = m.HardwareId,
+                Bounds = m.Bounds,
+                IsPrimary = m.IsPrimary,
+                Dpi = m.Dpi,
+                DisplayNumber = m.DisplayNumber,
+                IsDdcCiSupported = m.IsDdcCiSupported
+            }).ToList();
+
+            lock (_lock)
+            {
+                _cachedMonitors = copy;
             }
         }
 

--- a/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoProvider.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoProvider.cs
@@ -54,6 +54,9 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
         /// </summary>
         public bool GetDdcCiSupport(MonitorInfo monitor)
         {
+            if (string.IsNullOrEmpty(monitor.DeviceName))
+                return false;
+
             bool isSupported = false;
             string deviceName = monitor.DeviceName;
             NativeMethods.MonitorEnumProc callback = (IntPtr hMonitor, IntPtr hdcMonitor, ref NativeMethods.Rect lprcMonitor, IntPtr dwData) =>
@@ -86,8 +89,11 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
         /// </summary>
         public string GetHardwareId(MonitorInfo monitor)
         {
+            if (string.IsNullOrEmpty(monitor.DeviceName))
+                return string.Empty;
+
             string deviceName = monitor.DeviceName;
-            string hardwareId = null;
+            string? hardwareId = null;
             var displayDevice = new NativeMethods.DISPLAY_DEVICE { cb = Marshal.SizeOf(typeof(NativeMethods.DISPLAY_DEVICE)) };
             for (uint adapterIndex = 0; NativeMethods.EnumDisplayDevices(null, adapterIndex, ref displayDevice, 0); adapterIndex++)
             {
@@ -104,7 +110,7 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
                 }
                 if (hardwareId != null) break;
             }
-            return hardwareId;
+            return hardwareId ?? string.Empty;
         }
 
         /// <summary>

--- a/OLED-Sleeper/Features/MonitorState/Handlers/SynchronizeMonitorStateCommandHandler.cs
+++ b/OLED-Sleeper/Features/MonitorState/Handlers/SynchronizeMonitorStateCommandHandler.cs
@@ -3,6 +3,7 @@ using OLED_Sleeper.Features.MonitorBlackout.Services.Interfaces;
 using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
 using OLED_Sleeper.Features.MonitorIdleDetection.Services.Interfaces;
 using OLED_Sleeper.Features.MonitorInformation.Models;
+using OLED_Sleeper.Features.MonitorInformation.Services.Interfaces;
 using OLED_Sleeper.Features.MonitorState.Commands;
 using OLED_Sleeper.Features.UserSettings.Models;
 using OLED_Sleeper.Features.UserSettings.Services.Interfaces;
@@ -15,10 +16,10 @@ namespace OLED_Sleeper.Features.MonitorState.Handlers;
 /// <para>
 /// This handler is responsible for:
 /// <list type="bullet">
-/// <item><description>Stopping idle detection to reset state.</description></item>
 /// <item><description>Removing overlays and resetting brightness for all old and newly connected monitors.</description></item>
 /// <item><description>Updating managed monitor settings based on the new set of active monitors.</description></item>
-/// <item><description>Restarting idle detection with the updated settings.</description></item>
+/// <item><description>Aligning the monitor info cache and idle detection with the new topology without stopping the idle loop.</description></item>
+/// <item><description>Ensuring the idle detection loop is running.</description></item>
 /// </list>
 /// </para>
 /// </summary>
@@ -26,25 +27,25 @@ public class SynchronizeMonitorStateCommandHandler(
     IMonitorIdleDetectionService idleDetectionService,
     IMonitorSettingsFileService settingsFileService,
     IMonitorDimmingService dimmingService,
-    IMonitorBlackoutService blackoutService)
+    IMonitorBlackoutService blackoutService,
+    IMonitorInfoManager monitorInfoManager)
     : ICommandHandler<SynchronizeMonitorStateCommand>
 {
     /// <summary>
-    /// Handles the synchronization of monitor state by stopping idle detection, clearing overlays and brightness,
-    /// updating managed monitor settings, and restarting idle detection.
+    /// Handles the synchronization of monitor state by clearing overlays and brightness where needed,
+    /// updating managed monitor settings, refreshing the monitor cache, and applying topology to idle detection.
     /// </summary>
     /// <param name="command">The command containing the old and new monitor lists.</param>
     public Task HandleAsync(SynchronizeMonitorStateCommand command)
     {
-        idleDetectionService.Stop();
-
         RemoveOverlaysAndResetBrightness(command.OldMonitors);
         RemoveOverlaysAndResetBrightness(GetNewlyConnectedMonitors(command.NewMonitors, command.OldMonitors));
 
         var savedSettings = settingsFileService.LoadSettings();
         UpdateManagedSettings(savedSettings, command.NewMonitors);
 
-        idleDetectionService.UpdateSettings(savedSettings);
+        monitorInfoManager.UpdateCachedMonitorsFromSnapshot(command.NewMonitors);
+        idleDetectionService.ApplyTopologyAndSettings(savedSettings, command.NewMonitors);
         idleDetectionService.Start();
 
         Log.Information("Monitor state synchronized. Active monitors: {Count}", command.NewMonitors.Count);
@@ -59,6 +60,8 @@ public class SynchronizeMonitorStateCommandHandler(
     {
         foreach (var monitor in monitors)
         {
+            if (string.IsNullOrEmpty(monitor.HardwareId))
+                continue;
             blackoutService.HideBlackoutOverlayAsync(monitor.HardwareId);
             dimmingService.UndimMonitorAsync(monitor.HardwareId);
         }

--- a/OLED-Sleeper/Features/MonitorState/Services/MonitorStateWatcher.cs
+++ b/OLED-Sleeper/Features/MonitorState/Services/MonitorStateWatcher.cs
@@ -11,16 +11,25 @@ namespace OLED_Sleeper.Features.MonitorState.Services
     /// <summary>
     /// Monitors the set of connected displays and dispatches synchronization commands when changes are detected.
     /// This class polls the system for monitor changes and uses the mediator pattern to notify the application of state changes.
+    /// Topology changes are debounced: the same layout must be reported on several consecutive polls before a sync runs,
+    /// which avoids spurious syncs (and overlay churn) when enumeration flickers during display wake.
     /// </summary>
     public class MonitorStateWatcher : IMonitorStateWatcher
     {
         #region Fields
 
+        /// <summary>
+        /// Number of consecutive polls that must report the same topology before committing a sync.
+        /// </summary>
+        private const int RequiredStableTopologyPolls = 3;
+
         private readonly IMonitorInfoManager _monitorInfoManager;
         private readonly IMediator _mediator;
         private readonly Timer _pollTimer;
         private readonly object _lock = new();
-        private IReadOnlyList<MonitorInfo> _lastKnownMonitors = Array.Empty<MonitorInfo>();
+        private IReadOnlyList<MonitorInfo> _committedMonitors = Array.Empty<MonitorInfo>();
+        private List<MonitorInfo>? _pendingTopologySnapshot;
+        private int _stableTopologyPollCount;
 
         #endregion Fields
 
@@ -87,12 +96,13 @@ namespace OLED_Sleeper.Features.MonitorState.Services
         /// </summary>
         private void RetrieveInitialMonitorList()
         {
-            EventHandler<IReadOnlyList<MonitorInfo>> handler = null;
+            EventHandler<IReadOnlyList<MonitorInfo>>? handler = null;
             handler = (sender, monitors) =>
             {
                 _monitorInfoManager.MonitorListReady -= handler;
-                _lastKnownMonitors = monitors;
-                _mediator.SendAsync(new SynchronizeMonitorStateCommand([], _lastKnownMonitors));
+                _committedMonitors = CloneMonitorList(monitors);
+                ResetTopologyDebounce();
+                _mediator.SendAsync(new SynchronizeMonitorStateCommand([], _committedMonitors));
                 _pollTimer.Start();
             };
             _monitorInfoManager.MonitorListReady += handler;
@@ -100,29 +110,48 @@ namespace OLED_Sleeper.Features.MonitorState.Services
         }
 
         /// <summary>
-        /// Polls for monitor changes and dispatches a synchronization command if a change is detected.
+        /// Polls for monitor changes and dispatches a synchronization command once a new topology is stable across several polls.
         /// </summary>
         private void PollTimerElapsed(object? sender, ElapsedEventArgs e)
         {
             lock (_lock)
             {
                 var currentMonitors = _monitorInfoManager.GetLatestMonitorsBasicInfo();
-                if (!AreMonitorListsEqual(_lastKnownMonitors, currentMonitors))
+
+                if (AreMonitorListsEqual(_committedMonitors, currentMonitors))
                 {
-                    EnrichMonitorInfoList(currentMonitors);
-                    var oldMonitors = _lastKnownMonitors;
-                    _lastKnownMonitors = currentMonitors;
-                    _mediator.SendAsync(new SynchronizeMonitorStateCommand(oldMonitors, currentMonitors));
+                    ResetTopologyDebounce();
+                    return;
                 }
+
+                if (_pendingTopologySnapshot == null || !AreMonitorListsEqual(_pendingTopologySnapshot, currentMonitors))
+                {
+                    _pendingTopologySnapshot = CopyBasicTopology(currentMonitors);
+                    _stableTopologyPollCount = 1;
+                    return;
+                }
+
+                _stableTopologyPollCount++;
+                if (_stableTopologyPollCount < RequiredStableTopologyPolls)
+                    return;
+
+                EnrichMonitorInfoList(currentMonitors);
+                var oldCommitted = _committedMonitors;
+                _committedMonitors = CloneMonitorList(currentMonitors);
+                ResetTopologyDebounce();
+                _mediator.SendAsync(new SynchronizeMonitorStateCommand(oldCommitted, _committedMonitors));
             }
+        }
+
+        private void ResetTopologyDebounce()
+        {
+            _pendingTopologySnapshot = null;
+            _stableTopologyPollCount = 0;
         }
 
         /// <summary>
         /// Compares two monitor lists for equality based on device name set and count.
         /// </summary>
-        /// <param name="a">First monitor list.</param>
-        /// <param name="b">Second monitor list.</param>
-        /// <returns>True if the lists are equal; otherwise, false.</returns>
         private static bool AreMonitorListsEqual(IReadOnlyList<MonitorInfo>? a, IReadOnlyList<MonitorInfo>? b)
         {
             if (a == null || b == null) return false;
@@ -132,10 +161,36 @@ namespace OLED_Sleeper.Features.MonitorState.Services
             return aNames.SetEquals(bNames);
         }
 
+        private static List<MonitorInfo> CloneMonitorList(IReadOnlyList<MonitorInfo> source) =>
+            source.Select(CloneMonitorInfo).ToList();
+
+        private static MonitorInfo CloneMonitorInfo(MonitorInfo m) => new()
+        {
+            DeviceName = m.DeviceName,
+            HardwareId = m.HardwareId,
+            Bounds = m.Bounds,
+            IsPrimary = m.IsPrimary,
+            Dpi = m.Dpi,
+            DisplayNumber = m.DisplayNumber,
+            IsDdcCiSupported = m.IsDdcCiSupported
+        };
+
+        /// <summary>
+        /// Copies topology fields used for debounce comparison (hardware id is filled later during enrichment).
+        /// </summary>
+        private static List<MonitorInfo> CopyBasicTopology(IReadOnlyList<MonitorInfo> source) =>
+            source.Select(m => new MonitorInfo
+            {
+                DeviceName = m.DeviceName,
+                Bounds = m.Bounds,
+                IsPrimary = m.IsPrimary,
+                Dpi = m.Dpi,
+                DisplayNumber = m.DisplayNumber
+            }).ToList();
+
         /// <summary>
         /// Enriches a list of MonitorInfo objects with DDC/CI support and hardware ID.
         /// </summary>
-        /// <param name="monitors">The list of monitors to enrich.</param>
         private void EnrichMonitorInfoList(List<MonitorInfo> monitors)
         {
             _monitorInfoManager.EnrichMonitorInfoList(monitors);

--- a/OLED-Sleeper/Features/UserSettings/Models/MonitorSettings.cs
+++ b/OLED-Sleeper/Features/UserSettings/Models/MonitorSettings.cs
@@ -54,6 +54,11 @@ namespace OLED_Sleeper.Features.UserSettings.Models
         public bool IsActiveOnActiveWindow { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets a value indicating whether any visible window on this monitor (not necessarily focused) should reset idle state.
+        /// </summary>
+        public bool IsActiveOnVisibleWindows { get; set; } = false;
+
+        /// <summary>
         /// Gets the idle timeout in milliseconds, based on <see cref="IdleValue"/> and <see cref="IdleUnit"/>.
         /// </summary>
         public int IdleTimeMilliseconds

--- a/OLED-Sleeper/Native/NativeMethods.cs
+++ b/OLED-Sleeper/Native/NativeMethods.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.InteropServices;
+using System.Text;
 
 namespace OLED_Sleeper.Native
 {
@@ -64,6 +65,11 @@ namespace OLED_Sleeper.Native
         /// <seealso href="https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-monitorfromwindow"/>
         [DllImport("user32.dll")]
         public static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
+
+        /// <summary>
+        /// Returns <c>NULL</c> if the window does not intersect any display monitor.
+        /// </summary>
+        public const uint MONITOR_DEFAULTTONULL = 0;
 
         /// <summary>
         /// Determines the function's return value if the window does not intersect any display monitor.
@@ -190,6 +196,59 @@ namespace OLED_Sleeper.Native
         public const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
 
         /// <summary>
+        /// Use with <see cref="DwmGetWindowAttribute"/> to determine whether the window is cloaked (hidden by DWM).
+        /// </summary>
+        public const int DWMWA_CLOAKED = 14;
+
+        /// <summary>
+        /// Delegate for <see cref="EnumWindows"/>.
+        /// </summary>
+        /// <param name="hWnd">A handle to a top-level window.</param>
+        /// <param name="lParam">Application-defined value.</param>
+        /// <returns>Nonzero to continue enumeration; zero to stop.</returns>
+        public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+        /// <summary>
+        /// Enumerates all top-level windows on the screen.
+        /// </summary>
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+        /// <summary>
+        /// Determines whether the specified window handle identifies an existing window.
+        /// </summary>
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool IsWindow(IntPtr hWnd);
+
+        /// <summary>
+        /// Determines the visibility state of the specified window.
+        /// </summary>
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool IsWindowVisible(IntPtr hWnd);
+
+        /// <summary>
+        /// Determines whether the specified window is minimized.
+        /// </summary>
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool IsIconic(IntPtr hWnd);
+
+        /// <summary>
+        /// Retrieves a handle to the Shell's desktop window.
+        /// </summary>
+        [DllImport("user32.dll")]
+        public static extern IntPtr GetShellWindow();
+
+        /// <summary>
+        /// Retrieves the name of the class to which the specified window belongs.
+        /// </summary>
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
+        /// <summary>
         /// Delegate for monitor enumeration callback used by <see cref="EnumDisplayMonitors"/>.
         /// </summary>
         /// <param name="hMonitor">Handle to the display monitor.</param>
@@ -266,6 +325,12 @@ namespace OLED_Sleeper.Native
         /// <seealso href="https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/nf-dwmapi-dwmgetwindowattribute"/>
         [DllImport("dwmapi.dll")]
         public static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out Rect pvAttribute, int cbAttribute);
+
+        /// <summary>
+        /// Retrieves an integer Desktop Window Manager attribute (e.g. <see cref="DWMWA_CLOAKED"/>).
+        /// </summary>
+        [DllImport("dwmapi.dll", EntryPoint = "DwmGetWindowAttribute")]
+        public static extern int DwmGetWindowAttributeInt(IntPtr hwnd, int dwAttribute, out int pvAttribute, int cbAttribute);
 
         /// <summary>
         /// Retrieves a handle to the display monitor that has the largest area of intersection with a specified rectangle.

--- a/OLED-Sleeper/UI/Services/Interfaces/IWorkspaceService.cs
+++ b/OLED-Sleeper/UI/Services/Interfaces/IWorkspaceService.cs
@@ -12,7 +12,7 @@ namespace OLED_Sleeper.UI.Services.Interfaces
         /// <summary>
         /// Raised when the workspace has finished building and monitor layout view models are ready.
         /// </summary>
-        event EventHandler<ObservableCollection<MonitorLayoutViewModel>> WorkspaceReady;
+        event EventHandler<ObservableCollection<MonitorLayoutViewModel>>? WorkspaceReady;
 
         /// <summary>
         /// Begins building the workspace asynchronously by discovering monitors, loading settings, and constructing layout view models.

--- a/OLED-Sleeper/UI/Services/WorkspaceService.cs
+++ b/OLED-Sleeper/UI/Services/WorkspaceService.cs
@@ -18,7 +18,7 @@ namespace OLED_Sleeper.UI.Services
         private readonly IMonitorSettingsFileService _settingsService;
         private readonly IMonitorLayoutService _monitorLayoutService;
 
-        public event EventHandler<ObservableCollection<MonitorLayoutViewModel>> WorkspaceReady;
+        public event EventHandler<ObservableCollection<MonitorLayoutViewModel>>? WorkspaceReady;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WorkspaceService"/> class.
@@ -43,7 +43,7 @@ namespace OLED_Sleeper.UI.Services
         /// <param name="containerHeight">The height of the container.</param>
         public void BuildWorkspaceAsync(double containerWidth, double containerHeight)
         {
-            void Handler(object sender, System.Collections.Generic.IReadOnlyList<MonitorInfo> monitorInfos)
+            void Handler(object? sender, System.Collections.Generic.IReadOnlyList<MonitorInfo> monitorInfos)
             {
                 _monitorManager.MonitorListReady -= Handler;
                 var savedSettings = _settingsService.LoadSettings();
@@ -62,7 +62,7 @@ namespace OLED_Sleeper.UI.Services
         /// <param name="containerHeight">The height of the container for layout scaling.</param>
         public void RefreshWorkspaceAsync(double containerWidth, double containerHeight)
         {
-            void Handler(object sender, System.Collections.Generic.IReadOnlyList<MonitorInfo> monitorInfos)
+            void Handler(object? sender, System.Collections.Generic.IReadOnlyList<MonitorInfo> monitorInfos)
             {
                 _monitorManager.MonitorListReady -= Handler;
                 BuildWorkspaceAsync(containerWidth, containerHeight);

--- a/OLED-Sleeper/UI/ViewModels/MonitorConfigurationViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MonitorConfigurationViewModel.cs
@@ -223,6 +223,24 @@ namespace OLED_Sleeper.UI.ViewModels
             }
         }
 
+        private bool _isActiveOnVisibleWindows;
+        private bool _initialIsActiveOnVisibleWindows;
+
+        /// <summary>
+        /// Gets or sets whether any visible window on this monitor (even when not focused) keeps the monitor active.
+        /// </summary>
+        public bool IsActiveOnVisibleWindows
+        {
+            get => _isActiveOnVisibleWindows;
+            set
+            {
+                _isActiveOnVisibleWindows = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(ActiveConditionsError));
+                UpdateDirtyState();
+            }
+        }
+
         #endregion Properties
 
         /// <summary>
@@ -261,7 +279,8 @@ namespace OLED_Sleeper.UI.ViewModels
                        SelectedTimeUnit != _initialSelectedTimeUnit ||
                        IsActiveOnInput != _initialIsActiveOnInput ||
                        IsActiveOnMousePosition != _initialIsActiveOnMousePosition ||
-                       IsActiveOnActiveWindow != _initialIsActiveOnActiveWindow;
+                       IsActiveOnActiveWindow != _initialIsActiveOnActiveWindow ||
+                       IsActiveOnVisibleWindows != _initialIsActiveOnVisibleWindows;
 
             OnPropertyChanged(nameof(IsDirty));
             OnDirtyStateChanged?.Invoke();
@@ -280,6 +299,7 @@ namespace OLED_Sleeper.UI.ViewModels
             _initialIsActiveOnInput = IsActiveOnInput;
             _initialIsActiveOnMousePosition = IsActiveOnMousePosition;
             _initialIsActiveOnActiveWindow = IsActiveOnActiveWindow;
+            _initialIsActiveOnVisibleWindows = IsActiveOnVisibleWindows;
             UpdateDirtyState();
         }
 
@@ -297,6 +317,7 @@ namespace OLED_Sleeper.UI.ViewModels
             IsActiveOnInput = settings.IsActiveOnInput;
             IsActiveOnMousePosition = settings.IsActiveOnMousePosition;
             IsActiveOnActiveWindow = settings.IsActiveOnActiveWindow;
+            IsActiveOnVisibleWindows = settings.IsActiveOnVisibleWindows;
         }
 
         /// <summary>
@@ -307,7 +328,7 @@ namespace OLED_Sleeper.UI.ViewModels
         {
             return new MonitorSettings
             {
-                HardwareId = _monitorInfo.HardwareId,
+                HardwareId = _monitorInfo.HardwareId ?? string.Empty,
                 IsManaged = IsManaged,
                 Behavior = Behavior,
                 DimLevel = DimLevel,
@@ -315,7 +336,8 @@ namespace OLED_Sleeper.UI.ViewModels
                 IdleUnit = SelectedTimeUnit,
                 IsActiveOnInput = IsActiveOnInput,
                 IsActiveOnMousePosition = IsActiveOnMousePosition,
-                IsActiveOnActiveWindow = IsActiveOnActiveWindow
+                IsActiveOnActiveWindow = IsActiveOnActiveWindow,
+                IsActiveOnVisibleWindows = IsActiveOnVisibleWindows
             };
         }
 
@@ -363,6 +385,7 @@ namespace OLED_Sleeper.UI.ViewModels
                     case nameof(IsActiveOnInput):
                     case nameof(IsActiveOnMousePosition):
                     case nameof(IsActiveOnActiveWindow):
+                    case nameof(IsActiveOnVisibleWindows):
                         result = ValidateActiveConditions();
                         break;
 
@@ -391,7 +414,7 @@ namespace OLED_Sleeper.UI.ViewModels
         /// <returns>An error message if invalid, otherwise null.</returns>
         private string? ValidateActiveConditions()
         {
-            if (!IsActiveOnInput && !IsActiveOnMousePosition && !IsActiveOnActiveWindow)
+            if (!IsActiveOnInput && !IsActiveOnMousePosition && !IsActiveOnActiveWindow && !IsActiveOnVisibleWindows)
                 return "At least one 'Consider Active When' option must be selected.";
             return null;
         }

--- a/OLED-Sleeper/UI/ViewModels/MonitorLayoutViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MonitorLayoutViewModel.cs
@@ -61,7 +61,7 @@ namespace OLED_Sleeper.UI.ViewModels
         /// <summary>
         /// The hardware ID for the monitor.
         /// </summary>
-        public string HardwareId => _monitor.HardwareId;
+        public string HardwareId => _monitor.HardwareId ?? string.Empty;
 
         /// <summary>
         /// The resolution of the monitor as a formatted string (e.g., 1920x1080).

--- a/OLED-Sleeper/UI/Views/MonitorConfigurationView.xaml
+++ b/OLED-Sleeper/UI/Views/MonitorConfigurationView.xaml
@@ -404,6 +404,9 @@
                   • <Run FontWeight="SemiBold">Application is focused on this monitor:</Run><LineBreak />
                   <Span Foreground="{StaticResource SecondaryForegroundColor}">Keeps the monitor awake if it has the application you're currently using (the window you last clicked).</Span>
                   <LineBreak /><LineBreak />
+                  • <Run FontWeight="SemiBold">A visible window is on this monitor (not necessarily focused):</Run><LineBreak />
+                  <Span Foreground="{StaticResource SecondaryForegroundColor}">Useful when video or another app stays on this display while you work on a different monitor.</Span>
+                  <LineBreak /><LineBreak />
                   <Run FontWeight="SemiBold" TextDecorations="Underline">General Condition</Run><LineBreak />
                   This option is system-wide.<LineBreak /><LineBreak />
                   • <Run FontWeight="SemiBold">System-wide user input:</Run><LineBreak />
@@ -421,6 +424,8 @@
                         IsChecked="{Binding IsActiveOnMousePosition, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
                             <CheckBox Margin="0,0,0,8" Style="{StaticResource ModernCheckBox}" Content="Application is focused on this monitor"
                         IsChecked="{Binding IsActiveOnActiveWindow, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
+                            <CheckBox Margin="0,0,0,8" Style="{StaticResource ModernCheckBox}" Content="A visible window is on this monitor (not necessarily focused)"
+                        IsChecked="{Binding IsActiveOnVisibleWindows, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
                             <CheckBox Margin="0,0,0,0" Style="{StaticResource ModernCheckBox}" Content="System has user input"
                         IsChecked="{Binding IsActiveOnInput, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
                         </StackPanel>


### PR DESCRIPTION
The changes here were created with AI and should be reviewed as such. I'm primarily a Python and linux dev so I was able to get this up and running much, much faster with the help of AI, however, because of this, everything should be reviewed extra thoroughly.

This does work a bit differently than requested in the issue in that if there's a window open on the monitor, it will respect that and keep the monitor active. This was the functionality I wanted since if I had a video playing or a browser open on the window, I wanted it to stay active. Basically minimize any windows if you want the monitor to black out. It shouldn't be too hard to tweak this and add another option that is more in line with what is requested in the issue but the setting in this build is the more useful setting imo.

The changes.md file has a good overview of the implementation and I also fixed all the build warnings that were happening so you'll see those minor changes as well.