### PR TITLE
fix: properly detect and apply monitor geometry changes

### DIFF
--- a/OLED-Sleeper/Core/ApplicationOrchestrator.cs
+++ b/OLED-Sleeper/Core/ApplicationOrchestrator.cs
@@ -2,6 +2,7 @@
 using OLED_Sleeper.Features.MonitorBehavior.Commands;
 using OLED_Sleeper.Features.MonitorDimming.Commands;
 using OLED_Sleeper.Features.MonitorIdleDetection.Services.Interfaces;
+using OLED_Sleeper.Features.MonitorInformation.Services.Interfaces;
 using OLED_Sleeper.Features.MonitorState.Services.Interfaces;
 using OLED_Sleeper.Features.UserSettings.Models;
 using OLED_Sleeper.Features.UserSettings.Services.Interfaces;
@@ -29,6 +30,7 @@ namespace OLED_Sleeper.Core
     {
         private readonly IMediator _mediator;
         private readonly IMonitorIdleDetectionService _monitorIdleDetectionService;
+        private readonly IMonitorInfoManager _monitorInfoManager;
         private readonly IMonitorSettingsFileService _monitorSettingsFileService;
         private readonly IMonitorStateWatcher _monitorStateWatcher;
 
@@ -39,16 +41,19 @@ namespace OLED_Sleeper.Core
         /// </summary>
         /// <param name="mediator">Mediator for dispatching monitor-related commands.</param>
         /// <param name="monitorIdleDetectionService">Service for detecting monitor idle state and applying idle/active behaviors.</param>
+        /// <param name="monitorInfoManager">Service for querying current monitor information.</param>
         /// <param name="monitorSettingsFileService">Service for loading and saving monitor settings.</param>
         /// <param name="monitorStateWatcher">Service for monitoring system monitor connection/disconnection.</param>
         public ApplicationOrchestrator(
             IMediator mediator,
             IMonitorIdleDetectionService monitorIdleDetectionService,
+            IMonitorInfoManager monitorInfoManager,
             IMonitorSettingsFileService monitorSettingsFileService,
             IMonitorStateWatcher monitorStateWatcher)
         {
             _mediator = mediator;
             _monitorIdleDetectionService = monitorIdleDetectionService;
+            _monitorInfoManager = monitorInfoManager;
             _monitorSettingsFileService = monitorSettingsFileService;
             _monitorStateWatcher = monitorStateWatcher;
         }
@@ -140,12 +145,18 @@ namespace OLED_Sleeper.Core
         /// <remarks>
         /// The restore commands are issued only after the new settings are in effect, so a monitor cannot be
         /// restored and then immediately re-dimmed by the previous settings still being live.
+        /// <para>
+        /// This path is driven by the settings window, not by a display change, so the cached monitor list is
+        /// the right source for the geometry to join against — the display-change path passes its own freshly
+        /// scanned list instead.
+        /// </para>
         /// </remarks>
         private async Task ApplyChangedSettingsAsync(List<MonitorSettings> settings)
         {
             try
             {
-                await _monitorIdleDetectionService.UpdateSettingsAsync(settings);
+                var monitors = await _monitorInfoManager.GetCurrentMonitorsAsync();
+                await _monitorIdleDetectionService.UpdateSettingsAsync(settings, monitors);
 
                 foreach (var setting in settings)
                 {

--- a/OLED-Sleeper/Features/MonitorIdleDetection/Services/Interfaces/IMonitorIdleDetectionService.cs
+++ b/OLED-Sleeper/Features/MonitorIdleDetection/Services/Interfaces/IMonitorIdleDetectionService.cs
@@ -1,3 +1,4 @@
+using OLED_Sleeper.Features.MonitorInformation.Models;
 using OLED_Sleeper.Features.UserSettings.Models;
 
 namespace OLED_Sleeper.Features.MonitorIdleDetection.Services.Interfaces
@@ -22,7 +23,11 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services.Interfaces
         /// Updates the settings for all managed monitors.
         /// </summary>
         /// <param name="monitorSettings">The list of monitor settings to manage.</param>
+        /// <param name="monitors">
+        /// The monitors the settings are joined against, supplying the bounds used for hit-testing. The caller
+        /// passes the list it already holds so detection cannot be rebuilt against stale geometry.
+        /// </param>
         /// <returns>A task that completes once the new settings are in effect.</returns>
-        Task UpdateSettingsAsync(List<MonitorSettings> monitorSettings);
+        Task UpdateSettingsAsync(List<MonitorSettings> monitorSettings, IReadOnlyList<MonitorInfo> monitors);
     }
 }

--- a/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
+++ b/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
@@ -3,7 +3,6 @@ using OLED_Sleeper.Features.MonitorBehavior.Commands;
 using OLED_Sleeper.Features.MonitorIdleDetection.Models;
 using OLED_Sleeper.Features.MonitorIdleDetection.Services.Interfaces;
 using OLED_Sleeper.Features.MonitorInformation.Models;
-using OLED_Sleeper.Features.MonitorInformation.Services.Interfaces;
 using OLED_Sleeper.Features.UserSettings.Models;
 using OLED_Sleeper.Native;
 using Serilog;
@@ -26,7 +25,6 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         // === Dependencies & State ===
         private readonly IMediator _mediator;
 
-        private readonly IMonitorInfoManager _monitorManager;
         private CancellationTokenSource _cancellationTokenSource;
         private List<ManagedMonitorState> _managedMonitors = new();
         private readonly object _lock = new();
@@ -37,11 +35,9 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         /// <summary>
         /// Initializes a new instance of the <see cref="MonitorIdleDetectionService"/> class.
         /// </summary>
-        /// <param name="monitorManager">Service for monitor information.</param>
         /// <param name="mediator">Mediator for dispatching monitor behavior commands.</param>
-        public MonitorIdleDetectionService(IMonitorInfoManager monitorManager, IMediator mediator)
+        public MonitorIdleDetectionService(IMediator mediator)
         {
-            _monitorManager = monitorManager;
             _mediator = mediator;
         }
 
@@ -71,21 +67,26 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         /// Updates the settings for all managed monitors.
         /// </summary>
         /// <param name="monitorSettings">The list of monitor settings to manage.</param>
+        /// <param name="monitors">The monitors to join the settings against, supplying bounds and display numbers.</param>
         /// <remarks>
-        /// The monitor list is awaited *before* taking <see cref="_lock"/>. Acquiring this lock while the
-        /// monitor manager holds its own is what previously produced a lock-order inversion against the
-        /// idle loop; do not move the await inside the lock.
+        /// The monitor list is supplied by the caller rather than re-read here. The display-change watcher
+        /// already holds a freshly enriched list when it triggers this path; re-deriving it from the shared
+        /// cache discarded that and rebuilt hit-testing against whatever geometry the cache happened to hold,
+        /// which — since nothing invalidated the cache on a display change — was typically the startup scan.
+        /// <para>
+        /// This also keeps the monitor manager off this class's dependency list, so no lock it owns can ever
+        /// be taken while <see cref="_lock"/> is held. That ordering previously deadlocked against the idle loop.
+        /// </para>
         /// </remarks>
-        public async Task UpdateSettingsAsync(List<MonitorSettings> monitorSettings)
+        public Task UpdateSettingsAsync(List<MonitorSettings> monitorSettings, IReadOnlyList<MonitorInfo> monitors)
         {
             var activeSettings = monitorSettings.Where(s => s.IsManaged).ToList();
-            var allMonitors = await _monitorManager.GetCurrentMonitorsAsync();
 
             int trackedCount;
             lock (_lock)
             {
                 _managedMonitors = (from setting in activeSettings
-                                    join monitorInfo in allMonitors on setting.HardwareId equals monitorInfo.HardwareId
+                                    join monitorInfo in monitors on setting.HardwareId equals monitorInfo.HardwareId
                                     select new ManagedMonitorState
                                     {
                                         Settings = setting,
@@ -103,6 +104,7 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
             }
 
             Log.Information("MonitorIdleDetectionService settings updated. Now tracking {Count} monitors.", trackedCount);
+            return Task.CompletedTask;
         }
 
         // === Idle Detection Loop ===

--- a/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoManager.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoManager.cs
@@ -14,6 +14,7 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
         private readonly IMonitorInfoProvider _monitorInfoProvider;
         private readonly object _lock = new();
         private Task<IReadOnlyList<MonitorInfo>>? _cachedScan;
+        private Task<IReadOnlyList<MonitorInfo>>? _inFlightRefresh;
 
         #endregion Fields
 
@@ -42,12 +43,24 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// Callers that can fire repeatedly — the display-change watcher polls every 2s and a full scan can
+        /// take longer than that — share a single in-flight scan rather than each starting their own. Every
+        /// scan serialises DDC/CI probes on the same I²C bus, so concurrent scans do not just waste work,
+        /// they slow each other down.
+        /// </remarks>
         public Task<IReadOnlyList<MonitorInfo>> RefreshMonitorsAsync()
         {
-            Log.Information("Manual refresh requested. Re-scanning monitors.");
             lock (_lock)
             {
-                return _cachedScan = StartScan();
+                if (_inFlightRefresh is { IsCompleted: false })
+                {
+                    Log.Debug("Refresh requested while a scan is already running. Reusing the in-flight scan.");
+                    return _inFlightRefresh;
+                }
+
+                Log.Information("Refresh requested. Re-scanning monitors.");
+                return _cachedScan = _inFlightRefresh = StartScan();
             }
         }
 

--- a/OLED-Sleeper/Features/MonitorState/Handlers/SynchronizeMonitorStateCommandHandler.cs
+++ b/OLED-Sleeper/Features/MonitorState/Handlers/SynchronizeMonitorStateCommandHandler.cs
@@ -44,8 +44,10 @@ public class SynchronizeMonitorStateCommandHandler(
         var savedSettings = settingsFileService.LoadSettings();
         UpdateManagedSettings(savedSettings, command.NewMonitors);
 
-        // Awaited so idle detection restarts against the new settings rather than racing them.
-        await idleDetectionService.UpdateSettingsAsync(savedSettings);
+        // Awaited so idle detection restarts against the new settings rather than racing them. The command's
+        // monitor list is passed through rather than letting the service re-read the cache: this list is the
+        // freshly enriched one the watcher built for the change that triggered this handler.
+        await idleDetectionService.UpdateSettingsAsync(savedSettings, command.NewMonitors);
         idleDetectionService.Start();
 
         Log.Information("Monitor state synchronized. Active monitors: {Count}", command.NewMonitors.Count);

--- a/OLED-Sleeper/Features/MonitorState/Services/MonitorStateWatcher.cs
+++ b/OLED-Sleeper/Features/MonitorState/Services/MonitorStateWatcher.cs
@@ -22,6 +22,8 @@ namespace OLED_Sleeper.Features.MonitorState.Services
         private readonly Timer _pollTimer;
         private readonly object _lock = new();
         private IReadOnlyList<MonitorInfo> _lastKnownMonitors = Array.Empty<MonitorInfo>();
+        private IReadOnlyList<MonitorInfo>? _pendingMonitors;
+        private int _pollInProgress;
 
         #endregion Fields
 
@@ -109,27 +111,121 @@ namespace OLED_Sleeper.Features.MonitorState.Services
         /// Polls for monitor changes and dispatches a synchronization command if a change is detected.
         /// </summary>
         /// <remarks>
-        /// The lock covers only the comparison and the swap of <see cref="_lastKnownMonitors"/>. The mediator
-        /// dispatch runs outside it: <c>SynchronizeMonitorStateCommandHandler</c> reaches back into the
-        /// monitor manager and the dimming service, so holding this lock across the dispatch would reintroduce
-        /// a lock held across foreign code.
+        /// The timer is <c>AutoReset</c> at a shorter interval than a full monitor scan can take, so a tick
+        /// that arrives while the previous one is still working is dropped rather than queued. Without this
+        /// the poll would stack refreshes, each serialising DDC/CI probes on the same bus.
         /// </remarks>
         private void PollTimerElapsed(object? sender, ElapsedEventArgs e)
         {
-            IReadOnlyList<MonitorInfo> oldMonitors;
-            List<MonitorInfo> currentMonitors;
-
-            lock (_lock)
+            if (Interlocked.CompareExchange(ref _pollInProgress, 1, 0) != 0)
             {
-                currentMonitors = _monitorInfoManager.GetLatestMonitorsBasicInfo();
-                if (AreMonitorListsEqual(_lastKnownMonitors, currentMonitors)) return;
-
-                EnrichMonitorInfoList(currentMonitors);
-                oldMonitors = _lastKnownMonitors;
-                _lastKnownMonitors = currentMonitors;
+                Log.Debug("Skipping a monitor poll because the previous one is still running.");
+                return;
             }
 
-            _ = DispatchSynchronizationAsync(oldMonitors, currentMonitors);
+            _ = PollForChangesAsync();
+        }
+
+        /// <summary>
+        /// Reads the current display set, and when a change is confirmed, refreshes the shared monitor cache
+        /// and dispatches a synchronization command carrying the freshly enriched list.
+        /// </summary>
+        /// <remarks>
+        /// Neither the refresh nor the mediator dispatch runs under <see cref="_lock"/>. The lock covers only
+        /// the comparison and the swap of <see cref="_lastKnownMonitors"/>: a refresh performs slow native
+        /// probing, and <c>SynchronizeMonitorStateCommandHandler</c> reaches back into the monitor manager and
+        /// the dimming service, so holding this lock across either would reintroduce a lock held across
+        /// foreign code.
+        /// </remarks>
+        private async Task PollForChangesAsync()
+        {
+            try
+            {
+                var currentMonitors = _monitorInfoManager.GetLatestMonitorsBasicInfo();
+
+                if (currentMonitors.Count == 0)
+                {
+                    // A scan taken mid mode-change can succeed and still report nothing attached. An empty
+                    // list never compares equal to the last known one, so it must be rejected explicitly or
+                    // it would be acted on as though every monitor had been unplugged.
+                    Log.Debug("Monitor poll returned an empty display set. Treating it as transient.");
+                    ClearPendingChange();
+                    return;
+                }
+
+                if (!IsChangeConfirmed(currentMonitors)) return;
+
+                // Refresh the shared cache rather than enriching a private copy: the overlay handler and the
+                // settings UI read their geometry from that cache, and nothing else ever invalidates it.
+                var refreshedMonitors = await _monitorInfoManager.RefreshMonitorsAsync();
+
+                if (refreshedMonitors.Count == 0)
+                {
+                    Log.Warning("Monitor re-scan returned an empty display set. Keeping the last known monitor list.");
+                    return;
+                }
+
+                IReadOnlyList<MonitorInfo> oldMonitors;
+                lock (_lock)
+                {
+                    oldMonitors = _lastKnownMonitors;
+                    _lastKnownMonitors = refreshedMonitors;
+                }
+
+                await DispatchSynchronizationAsync(oldMonitors, refreshedMonitors);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to poll for display changes.");
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _pollInProgress, 0);
+            }
+        }
+
+        /// <summary>
+        /// Determines whether a detected difference from the last known monitor list is stable enough to act on.
+        /// </summary>
+        /// <param name="currentMonitors">The display set read by this poll.</param>
+        /// <returns>True if the same change has now been observed twice in a row; otherwise, false.</returns>
+        /// <remarks>
+        /// A display mode change is not atomic — mid-transition polls can observe geometry that exists for a
+        /// few hundred milliseconds and never again. Requiring two consecutive identical readings costs one
+        /// extra poll interval of latency and avoids synchronizing the whole application against a rectangle
+        /// that has already stopped being true.
+        /// </remarks>
+        private bool IsChangeConfirmed(IReadOnlyList<MonitorInfo> currentMonitors)
+        {
+            lock (_lock)
+            {
+                if (AreMonitorListsEqual(_lastKnownMonitors, currentMonitors))
+                {
+                    _pendingMonitors = null;
+                    return false;
+                }
+
+                if (!AreMonitorListsEqual(_pendingMonitors, currentMonitors))
+                {
+                    Log.Debug("Display change observed. Waiting for a second matching reading before acting.");
+                    _pendingMonitors = currentMonitors;
+                    return false;
+                }
+
+                _pendingMonitors = null;
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Discards any unconfirmed change so a transient reading cannot later be mistaken for a confirmation.
+        /// </summary>
+        private void ClearPendingChange()
+        {
+            lock (_lock)
+            {
+                _pendingMonitors = null;
+            }
         }
 
         /// <summary>
@@ -150,27 +246,59 @@ namespace OLED_Sleeper.Features.MonitorState.Services
         }
 
         /// <summary>
-        /// Compares two monitor lists for equality based on device name set and count.
+        /// Compares two monitor lists for equality by device name and per-monitor geometry.
         /// </summary>
         /// <param name="a">First monitor list.</param>
         /// <param name="b">Second monitor list.</param>
-        /// <returns>True if the lists are equal; otherwise, false.</returns>
+        /// <returns>True if the lists describe the same displays with the same geometry; otherwise, false.</returns>
+        /// <remarks>
+        /// Comparing only the set of device names made every geometry change invisible to the watcher: a
+        /// resolution change, a rearrangement in Windows display settings and a DPI/scaling change all
+        /// preserve both the count and the names, so no synchronization was ever dispatched and the rest of
+        /// the application kept acting on the bounds it had cached at startup.
+        /// <para>
+        /// <see cref="MonitorInfo.HardwareId"/> is deliberately *not* compared. This runs on every poll, and
+        /// the lists reaching it come from <c>GetLatestMonitorsBasicInfo</c>, which does not populate it —
+        /// obtaining it means a nested <c>EnumDisplayDevices</c> walk per monitor. The residual gap is a port
+        /// swap that substitutes a different panel under the same device name with identical geometry and no
+        /// observable intermediate state; unplugging and replugging passes through a changed display set and
+        /// is detected normally.
+        /// </para>
+        /// </remarks>
         private static bool AreMonitorListsEqual(IReadOnlyList<MonitorInfo>? a, IReadOnlyList<MonitorInfo>? b)
         {
             if (a == null || b == null) return false;
             if (a.Count != b.Count) return false;
-            var aNames = new HashSet<string>(a.Select(m => m.DeviceName).OfType<string>());
-            var bNames = new HashSet<string>(b.Select(m => m.DeviceName).OfType<string>());
-            return aNames.SetEquals(bNames);
+
+            var byDeviceName = new Dictionary<string, MonitorInfo>(a.Count);
+            foreach (var monitor in a)
+            {
+                if (monitor.DeviceName == null) return false;
+                if (!byDeviceName.TryAdd(monitor.DeviceName, monitor)) return false;
+            }
+
+            foreach (var monitor in b)
+            {
+                if (monitor.DeviceName == null) return false;
+                if (!byDeviceName.TryGetValue(monitor.DeviceName, out var counterpart)) return false;
+                if (!HasSameGeometry(monitor, counterpart)) return false;
+            }
+
+            return true;
         }
 
         /// <summary>
-        /// Enriches a list of MonitorInfo objects with DDC/CI support and hardware ID.
+        /// Compares the geometry-bearing fields of two records describing the same device name.
         /// </summary>
-        /// <param name="monitors">The list of monitors to enrich.</param>
-        private void EnrichMonitorInfoList(List<MonitorInfo> monitors)
+        /// <param name="a">First monitor record.</param>
+        /// <param name="b">Second monitor record.</param>
+        /// <returns>True if both describe the same rectangle, scaling and role; otherwise, false.</returns>
+        private static bool HasSameGeometry(MonitorInfo a, MonitorInfo b)
         {
-            _monitorInfoManager.EnrichMonitorInfoList(monitors);
+            return a.Bounds == b.Bounds
+                && a.Dpi == b.Dpi
+                && a.IsPrimary == b.IsPrimary
+                && a.DisplayNumber == b.DisplayNumber;
         }
 
         #endregion Private Methods


### PR DESCRIPTION
The display watcher now detects geometry changes, not just monitor count and device names.

* An overlay already showing when the resolution changes keeps its old size until the next activity/idle cycle.
* An instantaneous KVM port swap between identical monitors can still go undetected. Unplug and replug is caught.
* A change must be seen on two consecutive polls before it is acted on, and empty readings are rejected, so mid-mode-switch coordinates are not applied.
* `AreMonitorListsEqual` compares `Bounds`, `Dpi`, `IsPrimary` and `DisplayNumber`.
* `UpdateSettingsAsync` takes the fresh monitor list directly, so the measurements are no longer discarded before reaching the idle tracker.
* A confirmed change calls `RefreshMonitorsAsync()`, so the global cache no longer serves launch-time data to the overlay painter.
