### PR TITLE
fix: correct application startup and shutdown lifecycles

### DIFF
--- a/OLED-Sleeper/Core/ApplicationOrchestrator.cs
+++ b/OLED-Sleeper/Core/ApplicationOrchestrator.cs
@@ -67,21 +67,24 @@ namespace OLED_Sleeper.Core
         /// </summary>
         public void Start()
         {
-            SendRestoreBrightnessOnAllMonitorsCommand();
+            RestoreAllMonitors();
             SubscribeToEvents();
             InitializeStateWatcher();
         }
 
         /// <summary>
-        /// Stops the orchestrator, restores all monitor brightness, unsubscribes from events, and stops monitor state monitoring.
+        /// Unsubscribes from events, stops the idle loop and the state watcher, then restores all monitor
+        /// brightness. The returned task completes when the restore has finished.
         /// </summary>
-        public void Stop()
+        public async Task StopAsync()
         {
             Log.Information("ApplicationOrchestrator is stopping.");
-            RestoreAllMonitors();
+
             UnsubscribeFromEvents();
             _monitorIdleDetectionService.Stop();
             _monitorStateWatcher.Stop();
+
+            await RestoreAllMonitorsAsync();
         }
 
         #endregion Startup/Shutdown
@@ -119,12 +122,29 @@ namespace OLED_Sleeper.Core
         }
 
         /// <summary>
-        /// Restores all monitors' brightness levels to their normal state.
+        /// Restores all monitors' brightness levels to their normal state, without waiting for completion.
         /// </summary>
         public void RestoreAllMonitors()
         {
+            _ = RestoreAllMonitorsAsync();
+        }
+
+        /// <summary>
+        /// Restores all monitors' brightness levels to their normal state.
+        /// </summary>
+        private async Task RestoreAllMonitorsAsync()
+        {
             Log.Information("Restoring all monitors brightness levels...");
-            SendRestoreBrightnessOnAllMonitorsCommand();
+
+            try
+            {
+                await _mediator.SendAsync(new RestoreBrightnessOnAllMonitorsCommand());
+                Log.Information("RestoreBrightnessOnAllMonitorsCommand completed.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to restore monitor brightness levels.");
+            }
         }
 
         #endregion Monitor State Initialization & Restoration
@@ -172,16 +192,6 @@ namespace OLED_Sleeper.Core
         #endregion Monitor State Event Handlers
 
         #region Command Senders
-
-        /// <summary>
-        /// Sends a command to restore brightness for all monitors that may have been dimmed from a previous session.
-        /// </summary>
-        private void SendRestoreBrightnessOnAllMonitorsCommand()
-        {
-            var command = new RestoreBrightnessOnAllMonitorsCommand();
-            _mediator.SendAsync(command);
-            Log.Information("RestoreBrightnessOnAllMonitorsCommand sent.");
-        }
 
         /// <summary>
         /// Sends a command to restore a monitor's state by undimming it and hiding any blackout overlay.

--- a/OLED-Sleeper/Core/Interfaces/IApplicationOrchestrator.cs
+++ b/OLED-Sleeper/Core/Interfaces/IApplicationOrchestrator.cs
@@ -12,7 +12,8 @@
 
         /// <summary>
         /// Stops the orchestrator, unsubscribing from events and restoring monitor states.
+        /// The returned task completes when the restore has finished.
         /// </summary>
-        void Stop();
+        Task StopAsync();
     }
 }

--- a/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
+++ b/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
@@ -25,7 +25,7 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         // === Dependencies & State ===
         private readonly IMediator _mediator;
 
-        private CancellationTokenSource _cancellationTokenSource;
+        private CancellationTokenSource? _cancellationTokenSource;
         private List<ManagedMonitorState> _managedMonitors = new();
         private readonly object _lock = new();
         private readonly Dictionary<string, MonitorTimerState> _monitorStates = new();
@@ -44,22 +44,28 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         // === Service Lifecycle ===
 
         /// <summary>
-        /// Starts the idle detection service and begins monitoring.
+        /// Starts the idle detection service and begins monitoring. Any previous loop is stopped first.
         /// </summary>
         public void Start()
         {
-            _cancellationTokenSource = new CancellationTokenSource();
-            Task.Run(() => IdleCheckLoop(_cancellationTokenSource.Token));
+            Stop();
+
+            var cancellationTokenSource = new CancellationTokenSource();
+            _cancellationTokenSource = cancellationTokenSource;
+            Task.Run(() => IdleCheckLoop(cancellationTokenSource.Token));
             Log.Information("MonitorIdleDetectionService started.");
         }
 
         /// <summary>
-        /// Stops the idle detection service and monitoring.
+        /// Stops the idle detection service and monitoring. A second call does nothing.
         /// </summary>
         public void Stop()
         {
-            _cancellationTokenSource?.Cancel();
-            _cancellationTokenSource?.Dispose();
+            var cancellationTokenSource = Interlocked.Exchange(ref _cancellationTokenSource, null);
+            if (cancellationTokenSource == null) return;
+
+            cancellationTokenSource.Cancel();
+            cancellationTokenSource.Dispose();
             Log.Information("MonitorIdleDetectionService stopped.");
         }
 

--- a/OLED-Sleeper/Features/MonitorState/Services/Interfaces/IMonitorStateWatcher.cs
+++ b/OLED-Sleeper/Features/MonitorState/Services/Interfaces/IMonitorStateWatcher.cs
@@ -11,7 +11,7 @@ namespace OLED_Sleeper.Features.MonitorState.Services.Interfaces
         void Start();
 
         /// <summary>
-        /// Stops monitoring for monitor state changes.
+        /// Stops monitoring for monitor state changes. No synchronization is dispatched after this returns.
         /// </summary>
         void Stop();
     }

--- a/OLED-Sleeper/Features/MonitorState/Services/MonitorStateWatcher.cs
+++ b/OLED-Sleeper/Features/MonitorState/Services/MonitorStateWatcher.cs
@@ -24,6 +24,7 @@ namespace OLED_Sleeper.Features.MonitorState.Services
         private IReadOnlyList<MonitorInfo> _lastKnownMonitors = Array.Empty<MonitorInfo>();
         private IReadOnlyList<MonitorInfo>? _pendingMonitors;
         private int _pollInProgress;
+        private volatile bool _isStopped;
 
         #endregion Fields
 
@@ -57,14 +58,18 @@ namespace OLED_Sleeper.Features.MonitorState.Services
                 if (_pollTimer.Enabled) return;
             }
 
+            _isStopped = false;
             _ = RetrieveInitialMonitorListAsync();
         }
 
         /// <summary>
-        /// Stops monitoring for monitor state changes.
+        /// Stops monitoring for monitor state changes. A poll already in flight runs to completion but does
+        /// not dispatch a synchronization.
         /// </summary>
         public void Stop()
         {
+            _isStopped = true;
+
             lock (_lock)
             {
                 _pollTimer.Stop();
@@ -93,13 +98,20 @@ namespace OLED_Sleeper.Features.MonitorState.Services
             {
                 var monitors = await _monitorInfoManager.GetCurrentMonitorsAsync();
 
+                if (_isStopped) return;
+
                 lock (_lock)
                 {
                     _lastKnownMonitors = monitors;
                 }
 
                 await _mediator.SendAsync(new SynchronizeMonitorStateCommand([], monitors));
-                _pollTimer.Start();
+
+                lock (_lock)
+                {
+                    if (_isStopped) return;
+                    _pollTimer.Start();
+                }
             }
             catch (Exception ex)
             {
@@ -117,6 +129,8 @@ namespace OLED_Sleeper.Features.MonitorState.Services
         /// </remarks>
         private void PollTimerElapsed(object? sender, ElapsedEventArgs e)
         {
+            if (_isStopped) return;
+
             if (Interlocked.CompareExchange(ref _pollInProgress, 1, 0) != 0)
             {
                 Log.Debug("Skipping a monitor poll because the previous one is still running.");
@@ -162,6 +176,12 @@ namespace OLED_Sleeper.Features.MonitorState.Services
                 if (refreshedMonitors.Count == 0)
                 {
                     Log.Warning("Monitor re-scan returned an empty display set. Keeping the last known monitor list.");
+                    return;
+                }
+
+                if (_isStopped)
+                {
+                    Log.Debug("The watcher was stopped during this poll. Skipping synchronization.");
                     return;
                 }
 

--- a/OLED-Sleeper/Infrastructure/ApplicationBootstrapper.cs
+++ b/OLED-Sleeper/Infrastructure/ApplicationBootstrapper.cs
@@ -16,21 +16,35 @@ namespace OLED_Sleeper.Infrastructure
     /// </summary>
     public class ApplicationBootstrapper(string[] args) : IDisposable
     {
+        /// <summary>
+        /// How long shutdown waits for the monitor restore to finish.
+        /// </summary>
+        private const int RestoreOnShutdownTimeoutMs = 10000;
+
         private readonly ApplicationOptions _applicationOptions = CommandLineHelper.ParseArguments(args);
 
         private IServiceProvider? _serviceProvider;
         private ITrayIconService? _trayIconService;
         private IMainWindowService? _mainWindowService;
         private ApplicationInstanceManager? _instanceManager;
+        private IApplicationOrchestrator? _orchestrator;
         private bool _isExiting = false;
 
         /// <summary>
         /// Initializes the application: logging, single-instance, DI, orchestrator, main window, and tray icon.
+        /// A second instance stops after the single-instance check and starts no services.
         /// </summary>
         public void Initialize()
         {
             LoggingConfigurator.Configure();
             InitializeInstanceManager();
+
+            if (!_instanceManager!.IsFirstInstance)
+            {
+                Log.Information("Another instance is already running. Exiting without starting any services.");
+                return;
+            }
+
             ConfigureServices();
             StartOrchestrator();
 
@@ -63,8 +77,8 @@ namespace OLED_Sleeper.Infrastructure
         {
             if (_serviceProvider != null)
             {
-                var orchestrator = _serviceProvider.GetRequiredService<IApplicationOrchestrator>();
-                orchestrator.Start();
+                _orchestrator = _serviceProvider.GetRequiredService<IApplicationOrchestrator>();
+                _orchestrator.Start();
             }
         }
 
@@ -100,26 +114,52 @@ namespace OLED_Sleeper.Infrastructure
         }
 
         /// <summary>
-        /// Performs shutdown logic, including log flush and tray icon disposal.
-        /// Only the first instance will restore monitor states.
+        /// Stops the orchestrator, disposes the tray icon and the instance manager, flushes the log, and exits.
+        /// A second instance has no orchestrator and restores nothing.
         /// </summary>
         public void ShutdownApp()
         {
             if (_isExiting) return; // Prevent re-entrancy
             _isExiting = true;
 
-            if (_instanceManager?.IsFirstInstance == true)
-            {
-                Log.Information("Shutdown initiated. Restoring all monitors...");
-                ApplicationNotifications.TriggerRestoreAllMonitors();
-            }
+            StopOrchestrator();
+
+            _trayIconService?.Dispose();
+            _instanceManager?.Dispose();
 
             Log.Information("--- Application Exiting ---");
             Log.CloseAndFlush();
 
-            _trayIconService?.Dispose();
-            _instanceManager?.Dispose();
-            Application.Current.Shutdown();
+            Application.Current?.Shutdown();
+        }
+
+        /// <summary>
+        /// Stops the orchestrator and blocks until the monitor restore finishes or
+        /// <see cref="RestoreOnShutdownTimeoutMs"/> elapses.
+        /// </summary>
+        /// <remarks>
+        /// The restore runs on the thread pool: by the time <c>OnExit</c> reaches this, the UI thread is no
+        /// longer processing dispatcher messages. On timeout the brightness state file is left unchanged and
+        /// the next launch restores the monitor.
+        /// </remarks>
+        private void StopOrchestrator()
+        {
+            if (_orchestrator == null) return;
+
+            Log.Information("Shutdown initiated. Restoring all monitors...");
+
+            try
+            {
+                var stopTask = Task.Run(() => _orchestrator.StopAsync());
+                if (!stopTask.Wait(RestoreOnShutdownTimeoutMs))
+                {
+                    Log.Warning("Monitor restore did not finish within {TimeoutMs} ms. Exiting anyway.", RestoreOnShutdownTimeoutMs);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to stop the orchestrator during shutdown.");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
A second launch now exits without touching settings, and shutdown waits for brightness to be restored before the process ends.

* A second instance exits before modifying settings or adding a tray icon.
* Shutdown stops idle detection first, then waits for every monitor to restore, then exits.
* Logging stays up until the end of shutdown, so errors thrown while quitting reach the log file.
* The idle timer could be stopped twice, which threw during shutdown.
