### PR TITLE
fix: make brightness state file saves atomic with backup fallback

### DIFF
--- a/OLED-Sleeper/Features/MonitorDimming/Services/MonitorBrightnessStateService.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/MonitorBrightnessStateService.cs
@@ -11,6 +11,8 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
     public class MonitorBrightnessStateService : IMonitorBrightnessStateService
     {
         private readonly string _stateFilePath;
+        private readonly string _tempFilePath;
+        private readonly string _backupFilePath;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MonitorBrightnessStateService"/> class.
@@ -22,36 +24,36 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
             var settingsDir = Path.Combine(appDataPath, "OLED-Sleeper");
             Directory.CreateDirectory(settingsDir);
             _stateFilePath = Path.Combine(settingsDir, "brightness_state.json");
+            _tempFilePath = _stateFilePath + ".tmp";
+            _backupFilePath = _stateFilePath + ".bak";
         }
 
         #region IMonitorBrightnessStateService Implementation
 
         /// <summary>
         /// Loads the brightness state for all monitors from persistent storage.
+        /// Falls back to the backup file when the state file is missing or unreadable.
         /// </summary>
         /// <returns>A dictionary mapping monitor hardware IDs to their brightness values.</returns>
         public Dictionary<string, uint> LoadState()
         {
-            if (!File.Exists(_stateFilePath))
+            if (TryLoadFrom(_stateFilePath, out var state))
             {
-                return new Dictionary<string, uint>();
+                return state;
             }
 
-            try
+            if (TryLoadFrom(_backupFilePath, out var backupState))
             {
-                var json = File.ReadAllText(_stateFilePath);
-                var state = JsonSerializer.Deserialize<Dictionary<string, uint>>(json);
-                return state ?? new Dictionary<string, uint>();
+                Log.Warning("Loaded brightness state from the backup file {FilePath}.", _backupFilePath);
+                return backupState;
             }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to load brightness state from {FilePath}.", _stateFilePath);
-                return new Dictionary<string, uint>();
-            }
+
+            return new Dictionary<string, uint>();
         }
 
         /// <summary>
         /// Saves the brightness state for all monitors to persistent storage.
+        /// Writes to a temporary file and replaces the state file with it, keeping the previous contents as a backup.
         /// </summary>
         /// <param name="state">A dictionary mapping monitor hardware IDs to their brightness values.</param>
         public void SaveState(Dictionary<string, uint> state)
@@ -60,7 +62,16 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
             {
                 var options = new JsonSerializerOptions { WriteIndented = true };
                 var json = JsonSerializer.Serialize(state, options);
-                File.WriteAllText(_stateFilePath, json);
+                File.WriteAllText(_tempFilePath, json);
+
+                if (File.Exists(_stateFilePath))
+                {
+                    File.Replace(_tempFilePath, _stateFilePath, _backupFilePath, ignoreMetadataErrors: true);
+                }
+                else
+                {
+                    File.Move(_tempFilePath, _stateFilePath);
+                }
             }
             catch (Exception ex)
             {
@@ -69,5 +80,37 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
         }
 
         #endregion IMonitorBrightnessStateService Implementation
+
+        #region Private Methods
+
+        /// <summary>
+        /// Reads and deserializes a brightness state file.
+        /// </summary>
+        /// <param name="filePath">The path of the file to read.</param>
+        /// <param name="state">The deserialized state, or an empty dictionary when the file could not be read.</param>
+        /// <returns><c>true</c> if the file was read and deserialized; otherwise, <c>false</c>.</returns>
+        private static bool TryLoadFrom(string filePath, out Dictionary<string, uint> state)
+        {
+            state = new Dictionary<string, uint>();
+
+            if (!File.Exists(filePath))
+            {
+                return false;
+            }
+
+            try
+            {
+                var json = File.ReadAllText(filePath);
+                state = JsonSerializer.Deserialize<Dictionary<string, uint>>(json) ?? new Dictionary<string, uint>();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to load brightness state from {FilePath}.", filePath);
+                return false;
+            }
+        }
+
+        #endregion Private Methods
     }
 }


### PR DESCRIPTION
`brightness_state.json` is now written atomically, with the previous save kept as a `.bak` fallback.

* A `.bak` restore is one generation old, so a brightness recorded since the last successful save is lost.
* The write goes to `brightness_state.json.tmp` and is swapped in, so the target is never left half-written.
* The backup is loaded when the main file is missing or will not parse, instead of falling through to an empty list.
* Save frequency is unchanged: the original brightness is still persisted before the hardware write.
