### PR TITLE
fix: prevent settings data loss for disconnected monitors

### DIFF
--- a/OLED-Sleeper/Features/MonitorDimming/Services/MonitorDimmingService.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/MonitorDimmingService.cs
@@ -14,6 +14,9 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
     /// </summary>
     public class MonitorDimmingService : IMonitorDimmingService
     {
+        private readonly IMonitorInfoManager _monitorManager;
+        private readonly IMonitorBrightnessStateService _brightnessStateService;
+
         /// <summary>Number of times a restore write is attempted before the recording is kept and the attempt abandoned.</summary>
         private const int RestoreAttempts = 3;
 
@@ -25,9 +28,6 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
 
         /// <summary>Returned by <see cref="GetCurrentBrightness"/> when the monitor could not be read.</summary>
         private const uint BrightnessUnknown = uint.MaxValue;
-
-        private readonly IMonitorInfoManager _monitorManager;
-        private readonly IMonitorBrightnessStateService _brightnessStateService;
 
         /// <summary>Guards <see cref="_originalBrightnessLevels"/> and the state file write that follows each change to it.</summary>
         private readonly object _stateLock = new();

--- a/OLED-Sleeper/Features/UserSettings/Services/Interfaces/IMonitorSettingsFileService.cs
+++ b/OLED-Sleeper/Features/UserSettings/Services/Interfaces/IMonitorSettingsFileService.cs
@@ -19,7 +19,8 @@ namespace OLED_Sleeper.Features.UserSettings.Services.Interfaces
         List<MonitorSettings> LoadSettings();
 
         /// <summary>
-        /// Saves the provided monitor settings to persistent storage.
+        /// Saves the provided monitor settings to persistent storage. Stored settings for monitors that are
+        /// not in <paramref name="settings"/> are kept.
         /// </summary>
         /// <param name="settings">The list of monitor settings to save.</param>
         void SaveSettings(List<MonitorSettings> settings);

--- a/OLED-Sleeper/Features/UserSettings/Services/MonitorSettingsFileService.cs
+++ b/OLED-Sleeper/Features/UserSettings/Services/MonitorSettingsFileService.cs
@@ -59,24 +59,46 @@ namespace OLED_Sleeper.Features.UserSettings.Services
         }
 
         /// <summary>
-        /// Saves the specified monitor settings to the settings file.
-        /// Invokes the <see cref="SettingsChanged"/> event after successful save.
+        /// Saves the specified monitor settings to the settings file, keeping stored entries for monitors
+        /// the caller did not supply.
+        /// Invokes the <see cref="SettingsChanged"/> event with the supplied settings after a successful save.
         /// </summary>
         /// <param name="settings">The list of <see cref="MonitorSettings"/> to save.</param>
         public void SaveSettings(List<MonitorSettings> settings)
         {
             try
             {
+                var merged = MergeWithStoredSettings(settings);
                 var options = new JsonSerializerOptions { WriteIndented = true };
-                var json = JsonSerializer.Serialize(settings, options);
+                var json = JsonSerializer.Serialize(merged, options);
                 File.WriteAllText(_settingsFilePath, json);
-                Log.Information("Successfully saved {Count} monitor settings to {FilePath}.", settings.Count, _settingsFilePath);
+                Log.Information("Successfully saved {Count} monitor settings to {FilePath}.", merged.Count, _settingsFilePath);
                 SettingsChanged?.Invoke(settings);
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to save settings to {FilePath}.", _settingsFilePath);
             }
+        }
+
+        /// <summary>
+        /// Appends the stored settings whose hardware ID is absent from <paramref name="settings"/> to the
+        /// supplied list. The caller only ever builds settings for connected monitors, so without this the
+        /// write would drop the configuration of every disconnected one.
+        /// </summary>
+        /// <param name="settings">The settings supplied by the caller.</param>
+        /// <returns>The supplied settings followed by the stored settings that were kept.</returns>
+        private List<MonitorSettings> MergeWithStoredSettings(List<MonitorSettings> settings)
+        {
+            var suppliedIds = settings.Select(s => s.HardwareId).ToHashSet();
+            var retained = LoadSettings().Where(stored => !suppliedIds.Contains(stored.HardwareId)).ToList();
+
+            if (retained.Count > 0)
+            {
+                Log.Information("Kept stored settings for {Count} monitors that were not supplied.", retained.Count);
+            }
+
+            return settings.Concat(retained).ToList();
         }
     }
 }


### PR DESCRIPTION
Saving settings now merges with the stored file instead of overwriting it with the currently connected monitors.

* Settings for a disconnected monitor are kept rather than deleted when you save while it is unplugged.
* The `IsManaged` toggle survives an undock and redock.
