### PR TITLE
fix: synchronize blackout overlay collections to prevent stuck monitors

### DIFF
--- a/OLED-Sleeper/Features/MonitorBlackout/Services/MonitorBlackoutService.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Services/MonitorBlackoutService.cs
@@ -14,8 +14,22 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
     /// </summary>
     public class MonitorBlackoutService : IMonitorBlackoutService
     {
-        private readonly Dictionary<string, Window> _overlayWindows = new();
+        /// <summary>
+        /// Guards <see cref="_overlayWindows"/> and <see cref="_overlayHandles"/>. Overlays are created and
+        /// closed on the dispatcher thread while <see cref="IsOverlayWindow"/> reads from the idle thread.
+        /// Window creation, showing and closing all happen outside this lock.
+        /// </summary>
+        private readonly object _overlayLock = new();
+
+        private readonly Dictionary<string, OverlayRegistration> _overlayWindows = new();
         private readonly HashSet<nint> _overlayHandles = new();
+
+        /// <summary>
+        /// An overlay window paired with the handle it was tracked under.
+        /// </summary>
+        /// <param name="Window">The overlay window.</param>
+        /// <param name="Handle">The handle recorded when the overlay was shown, or zero if none was obtained.</param>
+        private readonly record struct OverlayRegistration(Window Window, nint Handle);
 
         /// <summary>
         /// Asynchronously shows a blackout overlay on the specified monitor.
@@ -27,7 +41,10 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
         {
             await Application.Current.Dispatcher.InvokeAsync(() =>
             {
-                if (_overlayWindows.ContainsKey(hardwareId)) return;
+                lock (_overlayLock)
+                {
+                    if (_overlayWindows.ContainsKey(hardwareId)) return;
+                }
 
                 var overlay = CreateOverlayWindow();
                 overlay.Show();
@@ -37,10 +54,17 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
                 {
                     ApplyNoActivateStyle(hwnd);
                     PositionOverlayToMonitor(hwnd, bounds);
-                    _overlayHandles.Add(hwnd);
                 }
 
-                _overlayWindows[hardwareId] = overlay;
+                lock (_overlayLock)
+                {
+                    if (hwnd != nint.Zero)
+                    {
+                        _overlayHandles.Add(hwnd);
+                    }
+
+                    _overlayWindows[hardwareId] = new OverlayRegistration(overlay, hwnd);
+                }
             });
         }
 
@@ -53,12 +77,21 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
         {
             await Application.Current.Dispatcher.InvokeAsync(() =>
             {
-                if (_overlayWindows.TryGetValue(hardwareId, out var overlay))
+                OverlayRegistration registration;
+
+                lock (_overlayLock)
                 {
-                    RemoveOverlayHandle(overlay);
-                    overlay.Close();
-                    _overlayWindows.Remove(hardwareId);
+                    if (!_overlayWindows.Remove(hardwareId, out registration)) return;
+
+                    // The stored handle is used rather than reading it back from the window, which
+                    // returns zero once the window is closed and would leave the handle in the set.
+                    if (registration.Handle != nint.Zero)
+                    {
+                        _overlayHandles.Remove(registration.Handle);
+                    }
                 }
+
+                registration.Window.Close();
             });
         }
 
@@ -67,8 +100,15 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
         /// </summary>
         /// <param name="windowHandle">The window handle to check.</param>
         /// <returns>True if the handle is an overlay window; otherwise, false.</returns>
-        public bool IsOverlayWindow(nint windowHandle) =>
-            windowHandle != nint.Zero && _overlayHandles.Contains(windowHandle);
+        public bool IsOverlayWindow(nint windowHandle)
+        {
+            if (windowHandle == nint.Zero) return false;
+
+            lock (_overlayLock)
+            {
+                return _overlayHandles.Contains(windowHandle);
+            }
+        }
 
         #region Private Helpers
 
@@ -115,19 +155,6 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
             nint extendedStyle = NativeMethods.GetWindowLongPtr(hwnd, NativeMethods.GWL_EXSTYLE);
             NativeMethods.SetWindowLongPtr(hwnd, NativeMethods.GWL_EXSTYLE,
                 new nint(extendedStyle.ToInt64() | NativeMethods.WS_EX_NOACTIVATE));
-        }
-
-        /// <summary>
-        /// Removes the overlay window handle from tracking before closing.
-        /// </summary>
-        /// <param name="overlay">The overlay window.</param>
-        private void RemoveOverlayHandle(Window overlay)
-        {
-            nint hwnd = new WindowInteropHelper(overlay).Handle;
-            if (hwnd != nint.Zero)
-            {
-                _overlayHandles.Remove(hwnd);
-            }
         }
 
         #endregion Private Helpers


### PR DESCRIPTION
Overlay tracking is guarded by a lock and keyed on a handle cached at creation.

* The idle thread and the UI thread both touched the overlay collections unlocked, so a torn read or a recycled handle made the app ignore real mouse movement and leave the monitor dark.
* A closing overlay could report a zero handle, leaving a stale entry Windows could later reassign to an ordinary window.
* `OverlayRegistration` caches the handle at creation; the lock covers only the collection access, not window creation, positioning or closing.
