### PR TITLE
feature: scale dimming percentages to actual physical monitor ranges

### DIFF
--- a/OLED-Sleeper/Features/MonitorDimming/Services/Interfaces/IMonitorDimmingService.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/Interfaces/IMonitorDimmingService.cs
@@ -9,7 +9,7 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services.Interfaces
         /// Dims the specified monitor to the given brightness level asynchronously.
         /// </summary>
         /// <param name="hardwareId">The unique hardware ID of the monitor.</param>
-        /// <param name="dimLevel">The brightness level to set (0-100).</param>
+        /// <param name="dimLevel">The dim level as a percentage (0-100), scaled into the monitor's own brightness range.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         Task DimMonitorAsync(string? hardwareId, int dimLevel);
 

--- a/OLED-Sleeper/Features/MonitorDimming/Services/MonitorDimmingService.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/MonitorDimmingService.cs
@@ -29,6 +29,9 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
         /// <summary>Returned by <see cref="GetCurrentBrightness"/> when the monitor could not be read.</summary>
         private const uint BrightnessUnknown = uint.MaxValue;
 
+        /// <summary>Upper bound of the percentage scale that the settings and the UI express the dim level on.</summary>
+        private const uint DimLevelPercentageMax = 100;
+
         /// <summary>Guards <see cref="_originalBrightnessLevels"/> and the state file write that follows each change to it.</summary>
         private readonly object _stateLock = new();
 
@@ -102,20 +105,62 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
         }
 
         /// <summary>
-        /// Reads the current brightness, records it as the original, then sets the dim level.
+        /// Scales the dim level into the monitor's brightness range, reads the current brightness,
+        /// records it as the original, then writes the scaled value.
         /// </summary>
         /// <param name="hardwareId">The hardware ID of the monitor.</param>
-        /// <param name="dimLevel">The brightness level to set.</param>
+        /// <param name="dimLevel">The dim level as a percentage.</param>
         private async Task DimCoreAsync(string hardwareId, int dimLevel)
         {
+            var targetBrightness = await ScaleToMonitorRangeAsync(hardwareId, dimLevel);
+
             await WithPhysicalMonitorAsync(hardwareId, hPhysicalMonitor =>
             {
                 var currentBrightness = GetCurrentBrightness(hPhysicalMonitor, hardwareId);
                 if (currentBrightness == BrightnessUnknown) return false;
 
                 RecordOriginalBrightness(hardwareId, currentBrightness);
-                return SetMonitorBrightness(hPhysicalMonitor, hardwareId, (uint)dimLevel);
+                return SetMonitorBrightness(hPhysicalMonitor, hardwareId, targetBrightness);
             });
+        }
+
+        /// <summary>
+        /// Converts a dim level percentage into a raw brightness value using the range the monitor reported
+        /// when it was last probed.
+        /// </summary>
+        /// <param name="hardwareId">The hardware ID of the monitor.</param>
+        /// <param name="dimLevel">The dim level as a percentage.</param>
+        /// <returns>The value to write to the monitor.</returns>
+        private async Task<uint> ScaleToMonitorRangeAsync(string hardwareId, int dimLevel)
+        {
+            var monitors = await _monitorManager.GetCurrentMonitorsAsync();
+            var maxBrightness = monitors.FirstOrDefault(m => m.HardwareId == hardwareId)?.MaxBrightness ?? 0;
+
+            var targetBrightness = ScaleToRange(dimLevel, maxBrightness);
+            if (targetBrightness != dimLevel)
+            {
+                Log.Debug("Dim level {DimLevel}% scales to brightness {TargetBrightness} on monitor {HardwareId}, whose range is 0-{MaxBrightness}.",
+                    dimLevel, targetBrightness, hardwareId, maxBrightness);
+            }
+
+            return targetBrightness;
+        }
+
+        /// <summary>
+        /// Maps a percentage onto a monitor's brightness range.
+        /// </summary>
+        /// <param name="dimLevelPercentage">The dim level as a percentage. Values outside 0-100 are clamped.</param>
+        /// <param name="maxBrightness">The monitor's highest accepted brightness value.</param>
+        /// <returns>
+        /// The percentage itself when the monitor reported no range or already runs on a 0-100 scale;
+        /// otherwise the percentage of <paramref name="maxBrightness"/>.
+        /// </returns>
+        private static uint ScaleToRange(int dimLevelPercentage, uint maxBrightness)
+        {
+            var percentage = (uint)Math.Clamp(dimLevelPercentage, 0, (int)DimLevelPercentageMax);
+            if (maxBrightness == 0 || maxBrightness == DimLevelPercentageMax) return percentage;
+
+            return (uint)Math.Round(percentage * maxBrightness / (double)DimLevelPercentageMax, MidpointRounding.AwayFromZero);
         }
 
         /// <summary>
@@ -352,7 +397,7 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
             }
             else
             {
-                Log.Information("Successfully dimmed monitor {HardwareId} to {DimLevel}%.", hardwareId, brightness);
+                Log.Information("Successfully dimmed monitor {HardwareId} to brightness {Brightness}.", hardwareId, brightness);
             }
 
             return true;

--- a/OLED-Sleeper/Features/MonitorInformation/Models/DdcCiCapabilities.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Models/DdcCiCapabilities.cs
@@ -1,0 +1,11 @@
+namespace OLED_Sleeper.Features.MonitorInformation.Models
+{
+    /// <summary>
+    /// What a single DDC/CI probe of a monitor reported.
+    /// </summary>
+    /// <param name="IsSupported">Whether the monitor answered a DDC/CI capabilities request.</param>
+    /// <param name="MaxBrightness">
+    /// The highest value the monitor accepts for the brightness VCP code. Zero when the monitor did not report a range.
+    /// </param>
+    public readonly record struct DdcCiCapabilities(bool IsSupported, uint MaxBrightness);
+}

--- a/OLED-Sleeper/Features/MonitorInformation/Models/MonitorInfo.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Models/MonitorInfo.cs
@@ -42,5 +42,11 @@ namespace OLED_Sleeper.Features.MonitorInformation.Models
         /// Gets or sets a value indicating whether DDC/CI is supported by this monitor.
         /// </summary>
         public bool IsDdcCiSupported { get; set; }
+
+        /// <summary>
+        /// Gets or sets the highest value the monitor accepts for the brightness VCP code.
+        /// Zero when the monitor has not been probed or reported no range.
+        /// </summary>
+        public uint MaxBrightness { get; set; }
     }
 }

--- a/OLED-Sleeper/Features/MonitorInformation/Services/Interfaces/IMonitorInfoProvider.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/Interfaces/IMonitorInfoProvider.cs
@@ -14,11 +14,11 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services.Interfaces
         List<MonitorInfo> GetAllMonitorsBasicInfo();
 
         /// <summary>
-        /// Returns whether the given monitor supports DDC/CI.
+        /// Probes the given monitor over DDC/CI for its support and its brightness range.
         /// </summary>
-        /// <param name="monitor">The monitor to check.</param>
-        /// <returns>True if DDC/CI is supported; otherwise, false.</returns>
-        bool GetDdcCiSupport(MonitorInfo monitor);
+        /// <param name="monitor">The monitor to probe.</param>
+        /// <returns>What the probe reported. Both fields are unset when the monitor did not answer.</returns>
+        DdcCiCapabilities GetDdcCiCapabilities(MonitorInfo monitor);
 
         /// <summary>
         /// Returns the hardware ID for the given monitor.

--- a/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoManager.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoManager.cs
@@ -76,7 +76,9 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
             if (monitors == null) return;
             foreach (var monitor in monitors)
             {
-                monitor.IsDdcCiSupported = _monitorInfoProvider.GetDdcCiSupport(monitor);
+                var capabilities = _monitorInfoProvider.GetDdcCiCapabilities(monitor);
+                monitor.IsDdcCiSupported = capabilities.IsSupported;
+                monitor.MaxBrightness = capabilities.MaxBrightness;
                 monitor.HardwareId = _monitorInfoProvider.GetHardwareId(monitor);
             }
         }

--- a/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoProvider.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoProvider.cs
@@ -50,11 +50,13 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
         }
 
         /// <summary>
-        /// Returns whether the given monitor supports DDC/CI.
+        /// Probes the given monitor over DDC/CI for its support and its brightness range.
+        /// Both are read from a single physical monitor handle.
         /// </summary>
-        public bool GetDdcCiSupport(MonitorInfo monitor)
+        public DdcCiCapabilities GetDdcCiCapabilities(MonitorInfo monitor)
         {
             bool isSupported = false;
+            uint maxBrightness = 0;
             string deviceName = monitor.DeviceName;
             NativeMethods.MonitorEnumProc callback = (IntPtr hMonitor, IntPtr hdcMonitor, ref NativeMethods.Rect lprcMonitor, IntPtr dwData) =>
             {
@@ -69,6 +71,12 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
                         if (NativeMethods.GetCapabilitiesStringLength(hPhysicalMonitor, out _))
                         {
                             isSupported = true;
+
+                            if (NativeMethods.GetVCPFeatureAndVCPFeatureReply(
+                                    hPhysicalMonitor, NativeMethods.VCP_CODE_BRIGHTNESS, nint.Zero, out _, out var reportedMax))
+                            {
+                                maxBrightness = reportedMax;
+                            }
                         }
                         NativeMethods.DestroyPhysicalMonitors(1, physicalMonitors);
                     }
@@ -77,8 +85,9 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
             };
 
             NativeMethods.EnumDisplayMonitors(nint.Zero, nint.Zero, callback, nint.Zero);
-            Log.Debug("DDC/CI support for monitor with DeviceName {DeviceName}: {IsSupported}", deviceName, isSupported);
-            return isSupported;
+            Log.Debug("DDC/CI probe for monitor with DeviceName {DeviceName}: supported {IsSupported}, maximum brightness {MaxBrightness}.",
+                deviceName, isSupported, maxBrightness);
+            return new DdcCiCapabilities(isSupported, maxBrightness);
         }
 
         /// <summary>


### PR DESCRIPTION
Dim percentages are now scaled to each monitor's actual raw brightness range.

* A monitor on a 0-255 scale received the percentage as a raw value, so a requested 15% arrived as about 6%.
* `MaxBrightness` is probed alongside DDC/CI support during enrichment and stored on `MonitorInfo`.
* Dimming log entries record the raw value sent to the panel, not the requested percentage.
