### PR TITLE
fix: remove all compile warnings

### DIFF
--- a/OLED-Sleeper.Tests/Features/MonitorBlackout/Handlers/HideBlackoutOverlayCommandHandlerTests.cs
+++ b/OLED-Sleeper.Tests/Features/MonitorBlackout/Handlers/HideBlackoutOverlayCommandHandlerTests.cs
@@ -52,10 +52,10 @@ namespace OLED_Sleeper.Tests.Features.MonitorBlackout.Handlers
         }
 
         [Fact]
-        public async Task HandleAsync_WithNullHardwareId_DoesNotThrow()
+        public async Task HandleAsync_WithEmptyHardwareId_DoesNotThrow()
         {
             // Arrange
-            var command = new HideBlackoutOverlayCommand { HardwareId = null };
+            var command = new HideBlackoutOverlayCommand { HardwareId = string.Empty };
 
             // Act
             var exception = await Record.ExceptionAsync(() => _handler.HandleAsync(command));

--- a/OLED-Sleeper/Features/MonitorBehavior/Commands/RestoreMonitorStateCommand.cs
+++ b/OLED-Sleeper/Features/MonitorBehavior/Commands/RestoreMonitorStateCommand.cs
@@ -9,8 +9,8 @@ namespace OLED_Sleeper.Features.MonitorBehavior.Commands
     public class RestoreMonitorStateCommand : ICommand
     {
         /// <summary>
-        /// Gets or sets the unique hardware ID of the monitor to be restored.
+        /// The unique hardware identifier of the target monitor.
         /// </summary>
-        public string HardwareId { get; set; }
+        public required string HardwareId { get; init; }
     }
 }

--- a/OLED-Sleeper/Features/MonitorBlackout/Commands/ApplyBlackoutOverlayCommand.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Commands/ApplyBlackoutOverlayCommand.cs
@@ -12,6 +12,6 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Commands
         /// <summary>
         /// The unique hardware identifier of the target monitor.
         /// </summary>
-        public string? HardwareId { get; init; }
+        public required string HardwareId { get; init; }
     }
 }

--- a/OLED-Sleeper/Features/MonitorBlackout/Commands/HideBlackoutOverlayCommand.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Commands/HideBlackoutOverlayCommand.cs
@@ -12,6 +12,6 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Commands
         /// <summary>
         /// The unique hardware identifier of the target monitor.
         /// </summary>
-        public string? HardwareId { get; init; }
+        public required string HardwareId { get; init; }
     }
 }

--- a/OLED-Sleeper/Features/MonitorDimming/Commands/ApplyDimCommand.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Commands/ApplyDimCommand.cs
@@ -11,7 +11,7 @@ namespace OLED_Sleeper.Features.MonitorDimming.Commands
         /// <summary>
         /// The unique hardware identifier of the target monitor.
         /// </summary>
-        public string? HardwareId { get; init; }
+        public required string HardwareId { get; init; }
 
         /// <summary>
         /// The brightness level to set (0-100).

--- a/OLED-Sleeper/Features/MonitorDimming/Commands/ApplyUndimCommand.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Commands/ApplyUndimCommand.cs
@@ -11,6 +11,6 @@ namespace OLED_Sleeper.Features.MonitorDimming.Commands
         /// <summary>
         /// The unique hardware identifier of the target monitor.
         /// </summary>
-        public string? HardwareId { get; init; }
+        public required string HardwareId { get; init; }
     }
 }

--- a/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
+++ b/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
@@ -346,7 +346,7 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
         private class ManagedMonitorState
         {
             public int DisplayNumber { get; set; }
-            public MonitorSettings Settings { get; set; }
+            public required MonitorSettings Settings { get; set; }
             public Rect Bounds { get; set; }
         }
 

--- a/OLED-Sleeper/Features/MonitorInformation/Models/MonitorInfo.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Models/MonitorInfo.cs
@@ -11,12 +11,13 @@ namespace OLED_Sleeper.Features.MonitorInformation.Models
         /// <summary>
         /// Gets or sets the device name (e.g., \\.\DISPLAY1).
         /// </summary>
-        public string? DeviceName { get; set; }
+        public string DeviceName { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the unique hardware ID for the monitor.
+        /// Empty until the monitor is enriched; an enriched list never contains an empty one.
         /// </summary>
-        public string? HardwareId { get; set; }
+        public string HardwareId { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the bounding rectangle of the monitor in screen coordinates.

--- a/OLED-Sleeper/Features/MonitorInformation/Services/Interfaces/IMonitorInfoProvider.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/Interfaces/IMonitorInfoProvider.cs
@@ -24,7 +24,7 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services.Interfaces
         /// Returns the hardware ID for the given monitor.
         /// </summary>
         /// <param name="monitor">The monitor to get the hardware ID for.</param>
-        /// <returns>The hardware ID string.</returns>
-        string GetHardwareId(MonitorInfo monitor);
+        /// <returns>The hardware ID string, or null when no attached display device matched the monitor.</returns>
+        string? GetHardwareId(MonitorInfo monitor);
     }
 }

--- a/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoManager.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoManager.cs
@@ -64,15 +64,30 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// A monitor whose hardware ID cannot be resolved is removed from the list.
+        /// </remarks>
         public void EnrichMonitorInfoList(List<MonitorInfo>? monitors)
         {
             if (monitors == null) return;
-            foreach (var monitor in monitors)
+            for (int index = monitors.Count - 1; index >= 0; index--)
             {
+                var monitor = monitors[index];
+
                 var capabilities = _monitorInfoProvider.GetDdcCiCapabilities(monitor);
                 monitor.IsDdcCiSupported = capabilities.IsSupported;
                 monitor.MaxBrightness = capabilities.MaxBrightness;
-                monitor.HardwareId = _monitorInfoProvider.GetHardwareId(monitor);
+
+                var hardwareId = _monitorInfoProvider.GetHardwareId(monitor);
+                if (string.IsNullOrEmpty(hardwareId))
+                {
+                    Log.Warning("No hardware ID resolved for {DeviceName}. The monitor is dropped and will not be managed.",
+                        monitor.DeviceName);
+                    monitors.RemoveAt(index);
+                    continue;
+                }
+
+                monitor.HardwareId = hardwareId;
             }
         }
 

--- a/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoProvider.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoProvider.cs
@@ -90,12 +90,12 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
         }
 
         /// <summary>
-        /// Returns the hardware ID for the given monitor.
+        /// Returns the hardware ID for the given monitor, or null when no attached display device matched it.
         /// </summary>
-        public string GetHardwareId(MonitorInfo monitor)
+        public string? GetHardwareId(MonitorInfo monitor)
         {
             string deviceName = monitor.DeviceName;
-            string hardwareId = null;
+            string? hardwareId = null;
             var displayDevice = new NativeMethods.DISPLAY_DEVICE { cb = Marshal.SizeOf(typeof(NativeMethods.DISPLAY_DEVICE)) };
             for (uint adapterIndex = 0; NativeMethods.EnumDisplayDevices(null, adapterIndex, ref displayDevice, 0); adapterIndex++)
             {

--- a/OLED-Sleeper/UI/Services/Interfaces/IWorkspaceService.cs
+++ b/OLED-Sleeper/UI/Services/Interfaces/IWorkspaceService.cs
@@ -12,7 +12,7 @@ namespace OLED_Sleeper.UI.Services.Interfaces
         /// <summary>
         /// Raised when the workspace has finished building and monitor layout view models are ready.
         /// </summary>
-        event EventHandler<ObservableCollection<MonitorLayoutViewModel>> WorkspaceReady;
+        event EventHandler<ObservableCollection<MonitorLayoutViewModel>>? WorkspaceReady;
 
         /// <summary>
         /// Builds the workspace by discovering monitors, loading settings, and constructing layout view models.

--- a/OLED-Sleeper/UI/Services/WorkspaceService.cs
+++ b/OLED-Sleeper/UI/Services/WorkspaceService.cs
@@ -18,7 +18,7 @@ namespace OLED_Sleeper.UI.Services
         private readonly IMonitorSettingsFileService _settingsService;
         private readonly IMonitorLayoutService _monitorLayoutService;
 
-        public event EventHandler<ObservableCollection<MonitorLayoutViewModel>> WorkspaceReady;
+        public event EventHandler<ObservableCollection<MonitorLayoutViewModel>>? WorkspaceReady;
 
         public WorkspaceService(
             IMonitorInfoManager monitorManager,


### PR DESCRIPTION
Monitors that fail to resolve a hardware ID are dropped at the source, which makes `HardwareId` and `DeviceName` non-nullable and clears the warnings.

* A monitor with no resolvable hardware ID no longer appears in the settings window at all.
* `EnrichMonitorInfoList` drops it and logs a warning.
* All four monitor commands take `required string HardwareId`, and `RestoreMonitorStateCommand` moves from `set` to `init`.
* Import-formatting warnings in `App.xaml.cs` and `ServiceConfigurator.cs` are left in place.
