### PR TITLE
refactor: extract dispatcher and overlay window seams to make MonitorBlackoutService testable

### DIFF
--- a/OLED-Sleeper.Tests/TestDoubles/FakeOverlayWindow.cs
+++ b/OLED-Sleeper.Tests/TestDoubles/FakeOverlayWindow.cs
@@ -1,0 +1,48 @@
+using OLED_Sleeper.Features.MonitorBlackout.Services.Interfaces;
+using System.Windows;
+
+namespace OLED_Sleeper.Tests.TestDoubles
+{
+    /// <summary>
+    /// An <see cref="IOverlayWindow"/> that records what it was asked to do instead of creating a window.
+    /// Its handle drops back to zero on <see cref="Close"/>, the same as a real overlay.
+    /// </summary>
+    public class FakeOverlayWindow : IOverlayWindow
+    {
+        private readonly nint _handleOnceShown;
+
+        /// <param name="handleOnceShown">The handle to report after <see cref="Show"/> runs. Zero
+        /// reproduces an overlay that never got a window handle.</param>
+        public FakeOverlayWindow(nint handleOnceShown)
+        {
+            _handleOnceShown = handleOnceShown;
+        }
+
+        /// <summary>
+        /// The bounds passed to <see cref="Show"/>, or null while the overlay has not been shown.
+        /// </summary>
+        public Rect? ShownBounds { get; private set; }
+
+        /// <summary>
+        /// True once <see cref="Close"/> has run.
+        /// </summary>
+        public bool IsClosed { get; private set; }
+
+        /// <inheritdoc />
+        public nint Handle { get; private set; }
+
+        /// <inheritdoc />
+        public void Show(Rect bounds)
+        {
+            ShownBounds = bounds;
+            Handle = _handleOnceShown;
+        }
+
+        /// <inheritdoc />
+        public void Close()
+        {
+            IsClosed = true;
+            Handle = nint.Zero;
+        }
+    }
+}

--- a/OLED-Sleeper.Tests/TestDoubles/FakeOverlayWindowFactory.cs
+++ b/OLED-Sleeper.Tests/TestDoubles/FakeOverlayWindowFactory.cs
@@ -1,0 +1,50 @@
+using OLED_Sleeper.Features.MonitorBlackout.Services.Interfaces;
+
+namespace OLED_Sleeper.Tests.TestDoubles
+{
+    /// <summary>
+    /// An <see cref="IOverlayWindowFactory"/> that hands out <see cref="FakeOverlayWindow"/> instances
+    /// and keeps every one it created.
+    /// </summary>
+    public class FakeOverlayWindowFactory : IOverlayWindowFactory
+    {
+        /// <summary>
+        /// The handle the first overlay reports when the caller does not pick one. Any non-zero value
+        /// works; zero is the "no handle" sentinel and would leave every overlay untracked.
+        /// </summary>
+        private const int DefaultFirstHandle = 1000;
+
+        private nint _nextHandle;
+
+        public FakeOverlayWindowFactory() : this(DefaultFirstHandle)
+        {
+        }
+
+        /// <param name="firstHandle">The handle the first overlay reports once shown; later overlays
+        /// count up from it. Zero makes every overlay report no handle at all.</param>
+        public FakeOverlayWindowFactory(nint firstHandle)
+        {
+            _nextHandle = firstHandle;
+        }
+
+        /// <summary>
+        /// Every overlay created so far, in creation order.
+        /// </summary>
+        public List<FakeOverlayWindow> Created { get; } = new();
+
+        /// <inheritdoc />
+        public IOverlayWindow Create()
+        {
+            var overlay = new FakeOverlayWindow(_nextHandle);
+
+            // A factory built with zero keeps handing out zero instead of moving off the sentinel.
+            if (_nextHandle != nint.Zero)
+            {
+                _nextHandle++;
+            }
+
+            Created.Add(overlay);
+            return overlay;
+        }
+    }
+}

--- a/OLED-Sleeper.Tests/TestDoubles/ImmediateDispatcher.cs
+++ b/OLED-Sleeper.Tests/TestDoubles/ImmediateDispatcher.cs
@@ -1,0 +1,39 @@
+using OLED_Sleeper.Core.Interfaces;
+
+namespace OLED_Sleeper.Tests.TestDoubles
+{
+    /// <summary>
+    /// An <see cref="IDispatcher"/> that runs actions on the calling thread and counts them, so a test
+    /// can assert work was handed to the UI thread without needing a real one.
+    /// </summary>
+    public class ImmediateDispatcher : IDispatcher
+    {
+        /// <summary>
+        /// How many actions have been run through <see cref="Invoke"/>.
+        /// </summary>
+        public int InvokeCount { get; private set; }
+
+        /// <summary>
+        /// How many actions have been run through <see cref="InvokeAsync"/>.
+        /// </summary>
+        public int InvokeAsyncCount { get; private set; }
+
+        /// <inheritdoc />
+        public bool IsOnUiThread => true;
+
+        /// <inheritdoc />
+        public void Invoke(Action action)
+        {
+            InvokeCount++;
+            action();
+        }
+
+        /// <inheritdoc />
+        public Task InvokeAsync(Action action)
+        {
+            InvokeAsyncCount++;
+            action();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/OLED-Sleeper/Core/Interfaces/IDispatcher.cs
+++ b/OLED-Sleeper/Core/Interfaces/IDispatcher.cs
@@ -1,0 +1,27 @@
+namespace OLED_Sleeper.Core.Interfaces
+{
+    /// <summary>
+    /// Defines the contract for running an action on the UI thread from any thread.
+    /// </summary>
+    public interface IDispatcher
+    {
+        /// <summary>
+        /// Gets true when the caller is already on the UI thread, false when it is on any other thread.
+        /// </summary>
+        bool IsOnUiThread { get; }
+
+        /// <summary>
+        /// Runs the action on the UI thread and waits for it to finish.
+        /// Runs it directly when the caller is already on the UI thread.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        void Invoke(Action action);
+
+        /// <summary>
+        /// Hands the action to the UI thread and returns without waiting for it to run.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        /// <returns>A task that completes once the action has finished.</returns>
+        Task InvokeAsync(Action action);
+    }
+}

--- a/OLED-Sleeper/Features/MonitorBlackout/Services/Interfaces/IOverlayWindow.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Services/Interfaces/IOverlayWindow.cs
@@ -1,0 +1,28 @@
+using System.Windows;
+
+namespace OLED_Sleeper.Features.MonitorBlackout.Services.Interfaces
+{
+    /// <summary>
+    /// Defines the contract for one blackout overlay window.
+    /// </summary>
+    public interface IOverlayWindow
+    {
+        /// <summary>
+        /// Gets the handle of the operating system window behind this overlay. Zero means there is no
+        /// such window: before <see cref="Show"/> runs, and again once the overlay has been closed.
+        /// </summary>
+        nint Handle { get; }
+
+        /// <summary>
+        /// Shows the overlay covering the given bounds, without taking focus from the active window.
+        /// Must be called on the UI thread.
+        /// </summary>
+        /// <param name="bounds">The monitor bounds in physical screen coordinates, not device-independent pixels.</param>
+        void Show(Rect bounds);
+
+        /// <summary>
+        /// Closes the overlay. Must be called on the UI thread.
+        /// </summary>
+        void Close();
+    }
+}

--- a/OLED-Sleeper/Features/MonitorBlackout/Services/Interfaces/IOverlayWindowFactory.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Services/Interfaces/IOverlayWindowFactory.cs
@@ -1,0 +1,14 @@
+namespace OLED_Sleeper.Features.MonitorBlackout.Services.Interfaces
+{
+    /// <summary>
+    /// Defines the contract for creating blackout overlay windows.
+    /// </summary>
+    public interface IOverlayWindowFactory
+    {
+        /// <summary>
+        /// Creates an overlay that has not been shown yet. Must be called on the UI thread.
+        /// </summary>
+        /// <returns>The new overlay.</returns>
+        IOverlayWindow Create();
+    }
+}

--- a/OLED-Sleeper/Features/MonitorBlackout/Services/MonitorBlackoutService.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Services/MonitorBlackoutService.cs
@@ -1,10 +1,6 @@
-﻿using OLED_Sleeper.Features.MonitorBlackout.Services.Interfaces;
-using OLED_Sleeper.Native;
-using System;
-using System.Collections.Generic;
+using OLED_Sleeper.Core.Interfaces;
+using OLED_Sleeper.Features.MonitorBlackout.Services.Interfaces;
 using System.Windows;
-using System.Windows.Interop;
-using System.Windows.Media;
 
 namespace OLED_Sleeper.Features.MonitorBlackout.Services
 {
@@ -14,6 +10,9 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
     /// </summary>
     public class MonitorBlackoutService : IMonitorBlackoutService
     {
+        private readonly IDispatcher _dispatcher;
+        private readonly IOverlayWindowFactory _overlayWindowFactory;
+
         /// <summary>
         /// Guards <see cref="_overlayWindows"/> and <see cref="_overlayHandles"/>. Overlays are created and
         /// closed on the dispatcher thread while <see cref="IsOverlayWindow"/> reads from the idle thread.
@@ -21,40 +20,45 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
         /// </summary>
         private readonly object _overlayLock = new();
 
+        /// <summary>
+        /// The overlay currently shown on each monitor, keyed by hardware ID. A monitor with no overlay
+        /// has no entry.
+        /// </summary>
         private readonly Dictionary<string, OverlayRegistration> _overlayWindows = new();
+
+        /// <summary>
+        /// The handles of every overlay currently shown, which is what <see cref="IsOverlayWindow"/>
+        /// answers from. Overlays that never got a handle are absent.
+        /// </summary>
         private readonly HashSet<nint> _overlayHandles = new();
+
+        public MonitorBlackoutService(IDispatcher dispatcher, IOverlayWindowFactory overlayWindowFactory)
+        {
+            _dispatcher = dispatcher;
+            _overlayWindowFactory = overlayWindowFactory;
+        }
 
         /// <summary>
         /// An overlay window paired with the handle it was tracked under.
         /// </summary>
         /// <param name="Window">The overlay window.</param>
         /// <param name="Handle">The handle recorded when the overlay was shown, or zero if none was obtained.</param>
-        private readonly record struct OverlayRegistration(Window Window, nint Handle);
+        private readonly record struct OverlayRegistration(IOverlayWindow Window, nint Handle);
 
-        /// <summary>
-        /// Asynchronously shows a blackout overlay on the specified monitor.
-        /// </summary>
-        /// <param name="hardwareId">The unique hardware ID of the monitor.</param>
-        /// <param name="bounds">The bounds of the monitor in screen coordinates.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <inheritdoc />
         public async Task ShowBlackoutOverlayAsync(string hardwareId, Rect bounds)
         {
-            await Application.Current.Dispatcher.InvokeAsync(() =>
+            await _dispatcher.InvokeAsync(() =>
             {
                 lock (_overlayLock)
                 {
                     if (_overlayWindows.ContainsKey(hardwareId)) return;
                 }
 
-                var overlay = CreateOverlayWindow();
-                overlay.Show();
+                var overlay = _overlayWindowFactory.Create();
+                overlay.Show(bounds);
 
-                nint hwnd = new WindowInteropHelper(overlay).Handle;
-                if (hwnd != nint.Zero)
-                {
-                    ApplyNoActivateStyle(hwnd);
-                    PositionOverlayToMonitor(hwnd, bounds);
-                }
+                nint hwnd = overlay.Handle;
 
                 lock (_overlayLock)
                 {
@@ -68,14 +72,10 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
             });
         }
 
-        /// <summary>
-        /// Asynchronously hides the blackout overlay for the specified monitor.
-        /// </summary>
-        /// <param name="hardwareId">The unique hardware ID of the monitor.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <inheritdoc />
         public async Task HideBlackoutOverlayAsync(string hardwareId)
         {
-            await Application.Current.Dispatcher.InvokeAsync(() =>
+            await _dispatcher.InvokeAsync(() =>
             {
                 OverlayRegistration registration;
 
@@ -83,8 +83,8 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
                 {
                     if (!_overlayWindows.Remove(hardwareId, out registration)) return;
 
-                    // WindowInteropHelper.Handle returns zero once the window is closed, so the handle
-                    // recorded at creation is used here.
+                    // An overlay reports a zero handle once it is closed, so the handle recorded when it
+                    // was shown is used here.
                     if (registration.Handle != nint.Zero)
                     {
                         _overlayHandles.Remove(registration.Handle);
@@ -95,11 +95,7 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
             });
         }
 
-        /// <summary>
-        /// Determines whether the specified window handle belongs to an overlay window.
-        /// </summary>
-        /// <param name="windowHandle">The window handle to check.</param>
-        /// <returns>True if the handle is an overlay window; otherwise, false.</returns>
+        /// <inheritdoc />
         public bool IsOverlayWindow(nint windowHandle)
         {
             if (windowHandle == nint.Zero) return false;
@@ -109,54 +105,5 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
                 return _overlayHandles.Contains(windowHandle);
             }
         }
-
-        #region Private Helpers
-
-        /// <summary>
-        /// Creates a new overlay window.
-        /// </summary>
-        /// <returns>A configured <see cref="Window"/> instance.</returns>
-        private static Window CreateOverlayWindow() =>
-            new()
-            {
-                Cursor = System.Windows.Input.Cursors.None,
-                WindowStyle = WindowStyle.None,
-                ResizeMode = ResizeMode.NoResize,
-                AllowsTransparency = true,
-                Background = Brushes.Black,
-                ShowInTaskbar = false,
-                Topmost = true,
-                WindowStartupLocation = WindowStartupLocation.Manual
-            };
-
-        /// <summary>
-        /// Positions the overlay window to exactly cover the monitor using physical screen coordinates.
-        /// </summary>
-        /// <param name="hwnd">The window handle.</param>
-        /// <param name="bounds">The monitor bounds in physical screen coordinates.</param>
-        private static void PositionOverlayToMonitor(nint hwnd, Rect bounds)
-        {
-            NativeMethods.SetWindowPos(
-                hwnd,
-                NativeMethods.HWND_TOPMOST,
-                (int)bounds.Left,
-                (int)bounds.Top,
-                (int)bounds.Width,
-                (int)bounds.Height,
-                NativeMethods.SWP_NOACTIVATE);
-        }
-
-        /// <summary>
-        /// Applies the WS_EX_NOACTIVATE style to prevent the overlay from stealing focus.
-        /// </summary>
-        /// <param name="hwnd">The window handle.</param>
-        private static void ApplyNoActivateStyle(nint hwnd)
-        {
-            nint extendedStyle = NativeMethods.GetWindowLongPtr(hwnd, NativeMethods.GWL_EXSTYLE);
-            NativeMethods.SetWindowLongPtr(hwnd, NativeMethods.GWL_EXSTYLE,
-                new nint(extendedStyle.ToInt64() | NativeMethods.WS_EX_NOACTIVATE));
-        }
-
-        #endregion Private Helpers
     }
 }

--- a/OLED-Sleeper/Features/MonitorBlackout/Services/OverlayWindow.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Services/OverlayWindow.cs
@@ -1,0 +1,82 @@
+using OLED_Sleeper.Features.MonitorBlackout.Services.Interfaces;
+using OLED_Sleeper.Native;
+using System.Diagnostics.CodeAnalysis;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media;
+
+namespace OLED_Sleeper.Features.MonitorBlackout.Services
+{
+    /// <summary>
+    /// A blackout overlay backed by a borderless, topmost WPF window.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class OverlayWindow : IOverlayWindow
+    {
+        /// <summary>
+        /// The black, borderless, topmost window shown over the monitor. Its startup location is manual
+        /// so that <see cref="Show"/> can place it in physical pixels.
+        /// </summary>
+        private readonly Window _window = new()
+        {
+            Cursor = System.Windows.Input.Cursors.None,
+            WindowStyle = WindowStyle.None,
+            ResizeMode = ResizeMode.NoResize,
+            AllowsTransparency = true,
+            Background = Brushes.Black,
+            ShowInTaskbar = false,
+            Topmost = true,
+            WindowStartupLocation = WindowStartupLocation.Manual
+        };
+
+        /// <inheritdoc />
+        public nint Handle => new WindowInteropHelper(_window).Handle;
+
+        /// <inheritdoc />
+        public void Show(Rect bounds)
+        {
+            _window.Show();
+
+            nint hwnd = Handle;
+            if (hwnd == nint.Zero) return;
+
+            ApplyNoActivateStyle(hwnd);
+            PositionToMonitor(hwnd, bounds);
+        }
+
+        /// <inheritdoc />
+        public void Close() => _window.Close();
+
+        #region Private Helpers
+
+        /// <summary>
+        /// Positions the overlay to exactly cover the monitor using physical screen coordinates.
+        /// </summary>
+        /// <param name="hwnd">The window handle.</param>
+        /// <param name="bounds">The monitor bounds in physical screen coordinates.</param>
+        private static void PositionToMonitor(nint hwnd, Rect bounds)
+        {
+            NativeMethods.SetWindowPos(
+                hwnd,
+                NativeMethods.HWND_TOPMOST,
+                (int)bounds.Left,
+                (int)bounds.Top,
+                (int)bounds.Width,
+                (int)bounds.Height,
+                NativeMethods.SWP_NOACTIVATE);
+        }
+
+        /// <summary>
+        /// Applies the WS_EX_NOACTIVATE style to prevent the overlay from stealing focus.
+        /// </summary>
+        /// <param name="hwnd">The window handle.</param>
+        private static void ApplyNoActivateStyle(nint hwnd)
+        {
+            nint extendedStyle = NativeMethods.GetWindowLongPtr(hwnd, NativeMethods.GWL_EXSTYLE);
+            NativeMethods.SetWindowLongPtr(hwnd, NativeMethods.GWL_EXSTYLE,
+                new nint(extendedStyle.ToInt64() | NativeMethods.WS_EX_NOACTIVATE));
+        }
+
+        #endregion Private Helpers
+    }
+}

--- a/OLED-Sleeper/Features/MonitorBlackout/Services/OverlayWindowFactory.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Services/OverlayWindowFactory.cs
@@ -1,0 +1,15 @@
+using OLED_Sleeper.Features.MonitorBlackout.Services.Interfaces;
+using System.Diagnostics.CodeAnalysis;
+
+namespace OLED_Sleeper.Features.MonitorBlackout.Services
+{
+    /// <summary>
+    /// Creates <see cref="OverlayWindow"/> instances.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class OverlayWindowFactory : IOverlayWindowFactory
+    {
+        /// <inheritdoc />
+        public IOverlayWindow Create() => new OverlayWindow();
+    }
+}

--- a/OLED-Sleeper/Infrastructure/ApplicationDispatcher.cs
+++ b/OLED-Sleeper/Infrastructure/ApplicationDispatcher.cs
@@ -1,0 +1,23 @@
+using OLED_Sleeper.Core.Interfaces;
+using System.Diagnostics.CodeAnalysis;
+using System.Windows;
+
+namespace OLED_Sleeper.Infrastructure
+{
+    /// <summary>
+    /// Runs actions on the WPF UI thread owned by <see cref="Application.Current"/>.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class ApplicationDispatcher : IDispatcher
+    {
+        /// <inheritdoc />
+        public bool IsOnUiThread => Application.Current.Dispatcher.CheckAccess();
+
+        /// <inheritdoc />
+        public void Invoke(Action action) => Application.Current.Dispatcher.Invoke(action);
+
+        /// <inheritdoc />
+        public async Task InvokeAsync(Action action) =>
+            await Application.Current.Dispatcher.InvokeAsync(action);
+    }
+}

--- a/OLED-Sleeper/Infrastructure/ServiceConfigurator.cs
+++ b/OLED-Sleeper/Infrastructure/ServiceConfigurator.cs
@@ -42,6 +42,7 @@ namespace OLED_Sleeper.Infrastructure
         {
             var services = new ServiceCollection();
             services.AddSingleton<IMediator, Mediator>();
+            services.AddSingleton<IDispatcher, ApplicationDispatcher>();
 
             services.AddTransient<ICommandHandler<ApplyMonitorActiveBehaviorCommand>, ApplyMonitorActiveBehaviorCommandHandler>();
             services.AddTransient<ICommandHandler<ApplyMonitorIdleBehaviorCommand>, ApplyMonitorIdleBehaviorCommandHandler>();
@@ -59,6 +60,7 @@ namespace OLED_Sleeper.Infrastructure
             services.AddSingleton<IMonitorStateWatcher, MonitorStateWatcher>();
             services.AddSingleton<IMonitorBrightnessStateService, MonitorBrightnessStateService>();
             services.AddSingleton<IMonitorDimmingService, MonitorDimmingService>();
+            services.AddSingleton<IOverlayWindowFactory, OverlayWindowFactory>();
             services.AddSingleton<IMonitorBlackoutService, MonitorBlackoutService>();
             services.AddSingleton<IApplicationOrchestrator, ApplicationOrchestrator>();
             services.AddSingleton<IWorkspaceService, WorkspaceService>();


### PR DESCRIPTION
`MonitorBlackoutService` gets dispatcher and overlay-window seams so its bookkeeping can be reached from a test.

* No tests in this PR. It adds the seams and the doubles; the `MonitorBlackoutService` tests land separately.
* No behaviour change: the overlay is created, styled and positioned as before, and the `_overlayLock` contract and cached-handle fix from #67 are untouched.
* Other classes still reaching `Application.Current.Dispatcher` directly are left alone.
* `IDispatcher` / `ApplicationDispatcher` wraps `Application.Current.Dispatcher`; the service marshals through the injected one.
* `IOverlayWindow` / `IOverlayWindowFactory` take window creation, `WS_EX_NOACTIVATE` and `SetWindowPos` into `OverlayWindow`, leaving the service about 85 lines lighter.
* `ImmediateDispatcher`, `FakeOverlayWindow` and `FakeOverlayWindowFactory` are added under `TestDoubles/`.
