### PR TITLE
refactor: route Application.Current through dispatcher, shutdown and main window seams

### DIFF
--- a/OLED-Sleeper.Tests/TestDoubles/ImmediateDispatcher.cs
+++ b/OLED-Sleeper.Tests/TestDoubles/ImmediateDispatcher.cs
@@ -9,6 +9,13 @@ namespace OLED_Sleeper.Tests.TestDoubles
     public class ImmediateDispatcher : IDispatcher
     {
         /// <summary>
+        /// How deep invokes may nest before <see cref="Run"/> throws.
+        /// </summary>
+        private const int MaxNestedInvokes = 8;
+
+        private int _nestedInvokes;
+
+        /// <summary>
         /// How many actions have been run through <see cref="Invoke"/>.
         /// </summary>
         public int InvokeCount { get; private set; }
@@ -18,22 +25,52 @@ namespace OLED_Sleeper.Tests.TestDoubles
         /// </summary>
         public int InvokeAsyncCount { get; private set; }
 
-        /// <inheritdoc />
-        public bool IsOnUiThread => true;
+        /// <summary>
+        /// Whether the caller counts as being on the UI thread. Starts true; set it to false to make a
+        /// class under test take its marshalling branch. Reads true while an action is running.
+        /// </summary>
+        public bool IsOnUiThread { get; set; } = true;
 
         /// <inheritdoc />
         public void Invoke(Action action)
         {
             InvokeCount++;
-            action();
+            Run(action);
         }
 
         /// <inheritdoc />
         public Task InvokeAsync(Action action)
         {
             InvokeAsyncCount++;
-            action();
+            Run(action);
             return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Runs the action as if on the UI thread. Throws when invokes nest more than
+        /// <see cref="MaxNestedInvokes"/> deep, which fails the test instead of overflowing the stack.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        private void Run(Action action)
+        {
+            if (_nestedInvokes >= MaxNestedInvokes)
+            {
+                throw new InvalidOperationException($"Dispatcher invokes nested more than {MaxNestedInvokes} deep.");
+            }
+
+            bool wasOnUiThread = IsOnUiThread;
+            _nestedInvokes++;
+            IsOnUiThread = true;
+
+            try
+            {
+                action();
+            }
+            finally
+            {
+                _nestedInvokes--;
+                IsOnUiThread = wasOnUiThread;
+            }
         }
     }
 }

--- a/OLED-Sleeper/Core/ApplicationInstanceManager.cs
+++ b/OLED-Sleeper/Core/ApplicationInstanceManager.cs
@@ -1,5 +1,4 @@
 ﻿using OLED_Sleeper.Core.Interfaces;
-using System.Windows;
 
 namespace OLED_Sleeper.Core
 {
@@ -7,7 +6,8 @@ namespace OLED_Sleeper.Core
     /// Enforces a single running instance of the application.
     /// If a second instance is launched, it signals the first instance to show its main window and exits silently.
     /// </summary>
-    public class ApplicationInstanceManager : IApplicationInstanceManager
+    public class ApplicationInstanceManager(IDispatcher dispatcher, IApplicationShutdown applicationShutdown)
+        : IApplicationInstanceManager
     {
         #region Constants
 
@@ -32,13 +32,6 @@ namespace OLED_Sleeper.Core
         public bool IsFirstInstance { get; private set; }
 
         #endregion Properties
-
-        #region Constructors
-
-        public ApplicationInstanceManager()
-        { }
-
-        #endregion Constructors
 
         #region Public Methods
 
@@ -88,7 +81,7 @@ namespace OLED_Sleeper.Core
             {
                 // If first instance hasn't created the event yet, just exit silently
             }
-            Application.Current.Shutdown();
+            applicationShutdown.Shutdown();
         }
 
         /// <summary>
@@ -114,7 +107,7 @@ namespace OLED_Sleeper.Core
                     _showWindowEvent.WaitOne();
                     if (_showMainWindowAction != null)
                     {
-                        Application.Current.Dispatcher.Invoke(_showMainWindowAction);
+                        dispatcher.Invoke(_showMainWindowAction);
                     }
                 }
                 catch

--- a/OLED-Sleeper/Core/Interfaces/IApplicationShutdown.cs
+++ b/OLED-Sleeper/Core/Interfaces/IApplicationShutdown.cs
@@ -1,0 +1,14 @@
+namespace OLED_Sleeper.Core.Interfaces
+{
+    /// <summary>
+    /// Defines the contract for ending the process.
+    /// </summary>
+    public interface IApplicationShutdown
+    {
+        /// <summary>
+        /// Asks the application to exit. Returns once the request is posted, before the process has
+        /// torn down, so anything that must happen first has to run before the call.
+        /// </summary>
+        void Shutdown();
+    }
+}

--- a/OLED-Sleeper/Core/Interfaces/IMainWindowAccessor.cs
+++ b/OLED-Sleeper/Core/Interfaces/IMainWindowAccessor.cs
@@ -1,0 +1,22 @@
+using System.Windows;
+
+namespace OLED_Sleeper.Core.Interfaces
+{
+    /// <summary>
+    /// Defines the contract for reaching the window the application treats as its main window.
+    /// </summary>
+    public interface IMainWindowAccessor
+    {
+        /// <summary>
+        /// Registers the window as the application's main window. Must be called on the UI thread.
+        /// </summary>
+        /// <param name="window">The window to register.</param>
+        void SetMainWindow(Window window);
+
+        /// <summary>
+        /// Hides the main window. Does nothing when no main window has been registered.
+        /// Must be called on the UI thread.
+        /// </summary>
+        void HideMainWindow();
+    }
+}

--- a/OLED-Sleeper/Infrastructure/ApplicationBootstrapper.cs
+++ b/OLED-Sleeper/Infrastructure/ApplicationBootstrapper.cs
@@ -23,6 +23,12 @@ namespace OLED_Sleeper.Infrastructure
 
         private readonly ApplicationOptions _applicationOptions = CommandLineHelper.ParseArguments(args);
 
+        /// <summary>
+        /// Ends the process. Created here rather than resolved, since shutdown has to work both
+        /// before the container is built and after it has been disposed.
+        /// </summary>
+        private readonly IApplicationShutdown _applicationShutdown = new ApplicationShutdown();
+
         private IServiceProvider? _serviceProvider;
         private ITrayIconService? _trayIconService;
         private IMainWindowService? _mainWindowService;
@@ -55,10 +61,11 @@ namespace OLED_Sleeper.Infrastructure
 
         /// <summary>
         /// Initializes the single-instance manager before any other services.
+        /// Its seams are constructed here because the check runs before the container exists.
         /// </summary>
         private void InitializeInstanceManager()
         {
-            _instanceManager = new ApplicationInstanceManager();
+            _instanceManager = new ApplicationInstanceManager(new ApplicationDispatcher(), _applicationShutdown);
             _instanceManager.Initialize();
         }
 
@@ -130,7 +137,7 @@ namespace OLED_Sleeper.Infrastructure
             Log.Information("--- Application Exiting ---");
             Log.CloseAndFlush();
 
-            Application.Current?.Shutdown();
+            _applicationShutdown.Shutdown();
         }
 
         /// <summary>

--- a/OLED-Sleeper/Infrastructure/ApplicationShutdown.cs
+++ b/OLED-Sleeper/Infrastructure/ApplicationShutdown.cs
@@ -1,0 +1,16 @@
+using OLED_Sleeper.Core.Interfaces;
+using System.Diagnostics.CodeAnalysis;
+using System.Windows;
+
+namespace OLED_Sleeper.Infrastructure
+{
+    /// <summary>
+    /// Ends the process by shutting down the running <see cref="Application"/>.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class ApplicationShutdown : IApplicationShutdown
+    {
+        /// <inheritdoc />
+        public void Shutdown() => Application.Current?.Shutdown();
+    }
+}

--- a/OLED-Sleeper/Infrastructure/MainWindowAccessor.cs
+++ b/OLED-Sleeper/Infrastructure/MainWindowAccessor.cs
@@ -1,0 +1,19 @@
+using OLED_Sleeper.Core.Interfaces;
+using System.Diagnostics.CodeAnalysis;
+using System.Windows;
+
+namespace OLED_Sleeper.Infrastructure
+{
+    /// <summary>
+    /// Reaches the main window through <see cref="Application.MainWindow"/>.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class MainWindowAccessor : IMainWindowAccessor
+    {
+        /// <inheritdoc />
+        public void SetMainWindow(Window window) => Application.Current.MainWindow = window;
+
+        /// <inheritdoc />
+        public void HideMainWindow() => Application.Current.MainWindow?.Hide();
+    }
+}

--- a/OLED-Sleeper/Infrastructure/ServiceConfigurator.cs
+++ b/OLED-Sleeper/Infrastructure/ServiceConfigurator.cs
@@ -43,6 +43,7 @@ namespace OLED_Sleeper.Infrastructure
             var services = new ServiceCollection();
             services.AddSingleton<IMediator, Mediator>();
             services.AddSingleton<IDispatcher, ApplicationDispatcher>();
+            services.AddSingleton<IMainWindowAccessor, MainWindowAccessor>();
 
             services.AddTransient<ICommandHandler<ApplyMonitorActiveBehaviorCommand>, ApplyMonitorActiveBehaviorCommandHandler>();
             services.AddTransient<ICommandHandler<ApplyMonitorIdleBehaviorCommand>, ApplyMonitorIdleBehaviorCommandHandler>();

--- a/OLED-Sleeper/UI/Services/MainWindowService.cs
+++ b/OLED-Sleeper/UI/Services/MainWindowService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Options;
+using OLED_Sleeper.Core.Interfaces;
 using OLED_Sleeper.Infrastructure;
 using OLED_Sleeper.UI.Services.Interfaces;
 using OLED_Sleeper.UI.ViewModels;
@@ -9,10 +10,11 @@ namespace OLED_Sleeper.UI.Services
     /// <summary>
     /// Provides methods to set up, show, and activate the main window.
     /// </summary>
-    /// <param name="mainWindow">The main application window.</param>
-    /// <param name="mainViewModel">The main view model for the window.</param>
-    /// <param name="options">The application configuration options.</param>
-    public class MainWindowService(MainWindow mainWindow, MainViewModel mainViewModel, IOptions<ApplicationOptions> options) : IMainWindowService
+    public class MainWindowService(
+        MainWindow mainWindow,
+        MainViewModel mainViewModel,
+        IOptions<ApplicationOptions> options,
+        IMainWindowAccessor mainWindowAccessor) : IMainWindowService
     {
         private readonly ApplicationOptions _options = options.Value;
 
@@ -22,7 +24,7 @@ namespace OLED_Sleeper.UI.Services
         /// </summary>
         public void SetupMainWindow()
         {
-            Application.Current.MainWindow = mainWindow;
+            mainWindowAccessor.SetMainWindow(mainWindow);
             mainWindow.DataContext = mainViewModel;
 
             if (_options.StartHidden)

--- a/OLED-Sleeper/UI/ViewModels/MainViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MainViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using OLED_Sleeper.Core;
+using OLED_Sleeper.Core.Interfaces;
 using OLED_Sleeper.Features.UserSettings.Services.Interfaces;
 using OLED_Sleeper.UI.Commands;
 using OLED_Sleeper.UI.Helpers;
@@ -6,7 +7,7 @@ using OLED_Sleeper.UI.Services.Interfaces;
 using Serilog;
 using System.Collections.ObjectModel;
 using System.Windows;
-using System.Windows.Input;
+using ICommand = System.Windows.Input.ICommand;
 
 namespace OLED_Sleeper.UI.ViewModels
 {
@@ -27,6 +28,16 @@ namespace OLED_Sleeper.UI.ViewModels
         /// Service for loading and saving monitor settings.
         /// </summary>
         private readonly IMonitorSettingsFileService _settingsService;
+
+        /// <summary>
+        /// Runs actions on the UI thread.
+        /// </summary>
+        private readonly IDispatcher _dispatcher;
+
+        /// <summary>
+        /// Reaches the application's main window.
+        /// </summary>
+        private readonly IMainWindowAccessor _mainWindowAccessor;
 
         /// <summary>
         /// The width of the container used for monitor layout calculations.
@@ -169,10 +180,16 @@ namespace OLED_Sleeper.UI.ViewModels
 
         #region Constructor
 
-        public MainViewModel(IWorkspaceService workspaceService, IMonitorSettingsFileService settingsService)
+        public MainViewModel(
+            IWorkspaceService workspaceService,
+            IMonitorSettingsFileService settingsService,
+            IDispatcher dispatcher,
+            IMainWindowAccessor mainWindowAccessor)
         {
             _workspaceService = workspaceService;
             _settingsService = settingsService;
+            _dispatcher = dispatcher;
+            _mainWindowAccessor = mainWindowAccessor;
 
             SelectMonitorCommand = new RelayCommand(ExecuteSelectMonitor);
             ReloadMonitorsCommand = new RelayCommand(() => RefreshMonitors(false));
@@ -244,7 +261,7 @@ namespace OLED_Sleeper.UI.ViewModels
                     SaveSettingsCommand.Execute(null);
                 }
             }
-            Application.Current.MainWindow?.Hide();
+            _mainWindowAccessor.HideMainWindow();
 
             return false;
         }
@@ -359,9 +376,9 @@ namespace OLED_Sleeper.UI.ViewModels
         /// <param name="newViewModels">The new monitor layout view models.</param>
         private void PopulateMonitors(ObservableCollection<MonitorLayoutViewModel> newViewModels)
         {
-            if (!Application.Current.Dispatcher.CheckAccess())
+            if (!_dispatcher.IsOnUiThread)
             {
-                Application.Current.Dispatcher.Invoke(() => PopulateMonitors(newViewModels));
+                _dispatcher.Invoke(() => PopulateMonitors(newViewModels));
                 return;
             }
 


### PR DESCRIPTION
`Application.Current` is now reached only from `ApplicationDispatcher`, `ApplicationShutdown` and `MainWindowAccessor`.

* `IApplicationShutdown` is not registered in `ServiceConfigurator`; both callers live outside the container.
* `ApplicationInstanceManager`'s seams are constructed by hand in `ApplicationBootstrapper`, because the single-instance check runs before the container exists.
* `PopulateMonitors` recurses through `Invoke`, so its guard is load-bearing; it is now `!_dispatcher.IsOnUiThread`, and `ImmediateDispatcher` throws past eight nested invokes so a lost guard fails a test rather than overflowing.
* `OnWindowClosing` still calls `MessageBox.Show` statically and `ApplicationInstanceManager.Initialize` still opens a real machine-wide mutex, so both stay untestable.
* `MainViewModel` aliases `using ICommand = System.Windows.Input.ICommand;` to avoid colliding with the mediator's marker.
