### PR TITLE
test: cover MainViewModel and route modal dialogs through IDialogService

### DIFF
--- a/OLED-Sleeper.Tests/UI/Helpers/MonitorSettingsValidatorTests.cs
+++ b/OLED-Sleeper.Tests/UI/Helpers/MonitorSettingsValidatorTests.cs
@@ -1,0 +1,99 @@
+using OLED_Sleeper.Features.MonitorBehavior.Models;
+using OLED_Sleeper.Features.MonitorInformation.Models;
+using OLED_Sleeper.UI.Helpers;
+using OLED_Sleeper.UI.ViewModels;
+using System.Windows;
+
+namespace OLED_Sleeper.Tests.UI.Helpers
+{
+    public class MonitorSettingsValidatorTests
+    {
+        [Fact]
+        public void BuildValidationError_WhenEveryManagedMonitorIsValid_ReturnsNull()
+        {
+            // Arrange
+            var monitor = CreateMonitor(1);
+            monitor.Configuration.IsManaged = true;
+            monitor.Configuration.Behavior = MonitorBehaviorType.Blackout;
+
+            // Act
+            var error = MonitorSettingsValidator.BuildValidationError(new[] { monitor });
+
+            // Assert
+            Assert.Null(error);
+        }
+
+        [Fact]
+        public void BuildValidationError_WhenAnInvalidMonitorIsUnmanaged_ReturnsNull()
+        {
+            // Arrange
+            var monitor = CreateMonitor(1);
+            monitor.Configuration.IdleValue = 0;
+
+            // Act
+            var error = MonitorSettingsValidator.BuildValidationError(new[] { monitor });
+
+            // Assert
+            Assert.Null(error);
+        }
+
+        [Fact]
+        public void BuildValidationError_WhenMonitorIsManagedAndInvalid_NamesItAndListsEveryProblem()
+        {
+            // Arrange
+            var monitor = CreateMonitor(2);
+            monitor.Configuration.IsManaged = true;
+            monitor.Configuration.IdleValue = null;
+            monitor.Configuration.IsActiveOnMousePosition = false;
+
+            // Act
+            var error = MonitorSettingsValidator.BuildValidationError(new[] { monitor });
+
+            // Assert
+            Assert.NotNull(error);
+            Assert.Contains("Monitor 2", error);
+            Assert.Contains("A monitor behavior must be selected.", error);
+            Assert.Contains("Idle time value must be a number greater than zero.", error);
+            Assert.Contains("At least one 'Consider Active When' option must be selected.", error);
+        }
+
+        [Fact]
+        public void BuildValidationError_WithSeveralInvalidMonitors_ListsThemAll()
+        {
+            // Arrange
+            var first = CreateMonitor(1);
+            var second = CreateMonitor(2);
+            var valid = CreateMonitor(3);
+            first.Configuration.IsManaged = true;
+            second.Configuration.IsManaged = true;
+            valid.Configuration.IsManaged = true;
+            valid.Configuration.Behavior = MonitorBehaviorType.Blackout;
+
+            // Act
+            var error = MonitorSettingsValidator.BuildValidationError(new[] { first, second, valid });
+
+            // Assert
+            Assert.NotNull(error);
+            Assert.Contains("Monitor 1", error);
+            Assert.Contains("Monitor 2", error);
+            Assert.DoesNotContain("Monitor 3", error);
+        }
+
+        /// <summary>
+        /// Builds a layout view model over a 1920x1080 monitor with default settings.
+        /// </summary>
+        private static MonitorLayoutViewModel CreateMonitor(int displayNumber)
+        {
+            var bounds = new Rect(0, 0, 1920, 1080);
+            var monitorInfo = new MonitorInfo
+            {
+                HardwareId = $"MON-{displayNumber}",
+                DisplayNumber = displayNumber,
+                DeviceName = $@"\\.\DISPLAY{displayNumber}",
+                Bounds = bounds
+            };
+
+            return new MonitorLayoutViewModel(monitorInfo, 1.0, bounds, 0, 0);
+        }
+    }
+}

--- a/OLED-Sleeper.Tests/UI/ViewModels/MainViewModelTests.cs
+++ b/OLED-Sleeper.Tests/UI/ViewModels/MainViewModelTests.cs
@@ -16,6 +16,7 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         private readonly Mock<IWorkspaceService> _workspaceServiceMock;
         private readonly Mock<IMonitorSettingsFileService> _settingsServiceMock;
         private readonly Mock<IMainWindowAccessor> _mainWindowAccessorMock;
+        private readonly Mock<IDialogService> _dialogServiceMock;
         private readonly ImmediateDispatcher _dispatcher;
         private readonly MainViewModel _viewModel;
 
@@ -24,6 +25,7 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
             _workspaceServiceMock = new Mock<IWorkspaceService>();
             _settingsServiceMock = new Mock<IMonitorSettingsFileService>();
             _mainWindowAccessorMock = new Mock<IMainWindowAccessor>();
+            _dialogServiceMock = new Mock<IDialogService>();
             _dispatcher = new ImmediateDispatcher();
 
             _workspaceServiceMock
@@ -37,7 +39,8 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
                 _workspaceServiceMock.Object,
                 _settingsServiceMock.Object,
                 _dispatcher,
-                _mainWindowAccessorMock.Object);
+                _mainWindowAccessorMock.Object,
+                _dialogServiceMock.Object);
         }
 
         [Fact]
@@ -306,6 +309,57 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
             // Assert
             Assert.False(shouldClose);
             _mainWindowAccessorMock.Verify(x => x.HideMainWindow(), Times.Once);
+            _dialogServiceMock.Verify(x => x.AskYesNoCancel(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public void OnWindowClosing_WhenDirtyAndUserCancels_KeepsWindowVisible()
+        {
+            // Arrange
+            _viewModel.IsDirty = true;
+            SetupUnsavedChangesAnswer(MessageBoxResult.Cancel);
+
+            // Act
+            var shouldClose = _viewModel.OnWindowClosing();
+
+            // Assert
+            Assert.False(shouldClose);
+            _mainWindowAccessorMock.Verify(x => x.HideMainWindow(), Times.Never);
+            _settingsServiceMock.Verify(x => x.SaveSettings(It.IsAny<List<MonitorSettings>>()), Times.Never);
+        }
+
+        [Fact]
+        public void OnWindowClosing_WhenDirtyAndUserSaves_SavesThenHides()
+        {
+            // Arrange
+            var monitor = CreateMonitor("MON-1");
+            RaiseWorkspaceReady(monitor);
+            monitor.Configuration.DimLevel = 50;
+            SetupUnsavedChangesAnswer(MessageBoxResult.Yes);
+
+            // Act
+            var shouldClose = _viewModel.OnWindowClosing();
+
+            // Assert
+            Assert.False(shouldClose);
+            _settingsServiceMock.Verify(x => x.SaveSettings(It.IsAny<List<MonitorSettings>>()), Times.Once);
+            _mainWindowAccessorMock.Verify(x => x.HideMainWindow(), Times.Once);
+        }
+
+        [Fact]
+        public void OnWindowClosing_WhenDirtyAndUserDiscards_HidesWithoutSaving()
+        {
+            // Arrange
+            _viewModel.IsDirty = true;
+            SetupUnsavedChangesAnswer(MessageBoxResult.No);
+
+            // Act
+            var shouldClose = _viewModel.OnWindowClosing();
+
+            // Assert
+            Assert.False(shouldClose);
+            _settingsServiceMock.Verify(x => x.SaveSettings(It.IsAny<List<MonitorSettings>>()), Times.Never);
+            _mainWindowAccessorMock.Verify(x => x.HideMainWindow(), Times.Once);
         }
 
         [Fact]
@@ -332,6 +386,64 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
             Assert.Equal(50, entry.DimLevel);
             Assert.False(_viewModel.IsDirty);
             Assert.Equal("Saved!", _viewModel.SaveButtonText);
+        }
+
+        [Fact]
+        public void SaveSettingsCommand_WhenSettingsInvalid_ShowsErrorAndDoesNotSave()
+        {
+            // Arrange
+            var monitor = CreateMonitor("MON-1");
+            RaiseWorkspaceReady(monitor);
+            monitor.Configuration.IsManaged = true;
+
+            // Act
+            _viewModel.SaveSettingsCommand.Execute(null);
+
+            // Assert
+            _dialogServiceMock.Verify(x => x.ShowError(It.IsAny<string>(), "Monitor Configuration Error"), Times.Once);
+            _settingsServiceMock.Verify(x => x.SaveSettings(It.IsAny<List<MonitorSettings>>()), Times.Never);
+            Assert.Equal("Save Settings", _viewModel.SaveButtonText);
+            Assert.True(_viewModel.IsDirty);
+        }
+
+        [Fact]
+        public void SaveAndDiscardCommands_WhenNothingIsDirty_CannotExecute()
+        {
+            // Arrange
+            RaiseWorkspaceReady(CreateMonitor("MON-1"));
+
+            // Act
+            var canSave = _viewModel.SaveSettingsCommand.CanExecute(null);
+            var canDiscard = _viewModel.DiscardChangesCommand.CanExecute(null);
+
+            // Assert
+            Assert.False(canSave);
+            Assert.False(canDiscard);
+        }
+
+        [Fact]
+        public void SaveAndDiscardCommands_WhenAMonitorIsDirty_CanExecute()
+        {
+            // Arrange
+            var monitor = CreateMonitor("MON-1");
+            RaiseWorkspaceReady(monitor);
+
+            // Act
+            monitor.Configuration.DimLevel = 50;
+
+            // Assert
+            Assert.True(_viewModel.SaveSettingsCommand.CanExecute(null));
+            Assert.True(_viewModel.DiscardChangesCommand.CanExecute(null));
+        }
+
+        /// <summary>
+        /// Makes the unsaved-changes prompt return the supplied answer.
+        /// </summary>
+        private void SetupUnsavedChangesAnswer(MessageBoxResult answer)
+        {
+            _dialogServiceMock
+                .Setup(x => x.AskYesNoCancel(It.IsAny<string>(), "Unsaved Changes"))
+                .Returns(answer);
         }
 
         /// <summary>

--- a/OLED-Sleeper.Tests/UI/ViewModels/MainViewModelTests.cs
+++ b/OLED-Sleeper.Tests/UI/ViewModels/MainViewModelTests.cs
@@ -1,0 +1,365 @@
+using Moq;
+using OLED_Sleeper.Core.Interfaces;
+using OLED_Sleeper.Features.MonitorInformation.Models;
+using OLED_Sleeper.Features.UserSettings.Models;
+using OLED_Sleeper.Features.UserSettings.Services.Interfaces;
+using OLED_Sleeper.Tests.TestDoubles;
+using OLED_Sleeper.UI.Services.Interfaces;
+using OLED_Sleeper.UI.ViewModels;
+using System.Collections.ObjectModel;
+using System.Windows;
+
+namespace OLED_Sleeper.Tests.UI.ViewModels
+{
+    public class MainViewModelTests
+    {
+        private readonly Mock<IWorkspaceService> _workspaceServiceMock;
+        private readonly Mock<IMonitorSettingsFileService> _settingsServiceMock;
+        private readonly Mock<IMainWindowAccessor> _mainWindowAccessorMock;
+        private readonly ImmediateDispatcher _dispatcher;
+        private readonly MainViewModel _viewModel;
+
+        public MainViewModelTests()
+        {
+            _workspaceServiceMock = new Mock<IWorkspaceService>();
+            _settingsServiceMock = new Mock<IMonitorSettingsFileService>();
+            _mainWindowAccessorMock = new Mock<IMainWindowAccessor>();
+            _dispatcher = new ImmediateDispatcher();
+
+            _workspaceServiceMock
+                .Setup(x => x.BuildWorkspaceAsync(It.IsAny<double>(), It.IsAny<double>()))
+                .Returns(Task.CompletedTask);
+            _workspaceServiceMock
+                .Setup(x => x.RefreshWorkspaceAsync(It.IsAny<double>(), It.IsAny<double>()))
+                .Returns(Task.CompletedTask);
+
+            _viewModel = new MainViewModel(
+                _workspaceServiceMock.Object,
+                _settingsServiceMock.Object,
+                _dispatcher,
+                _mainWindowAccessorMock.Object);
+        }
+
+        [Fact]
+        public void WorkspaceReady_PopulatesMonitors()
+        {
+            // Arrange
+            var first = CreateMonitor("MON-1");
+            var second = CreateMonitor("MON-2", 2);
+
+            // Act
+            RaiseWorkspaceReady(first, second);
+
+            // Assert
+            Assert.Equal(new[] { first, second }, _viewModel.Monitors);
+        }
+
+        [Fact]
+        public void WorkspaceReady_WhenRaisedAgain_ReplacesPreviousMonitors()
+        {
+            // Arrange
+            RaiseWorkspaceReady(CreateMonitor("MON-1"), CreateMonitor("MON-2", 2));
+            var replacement = CreateMonitor("MON-3", 3);
+
+            // Act
+            RaiseWorkspaceReady(replacement);
+
+            // Assert
+            Assert.Equal(new[] { replacement }, _viewModel.Monitors);
+        }
+
+        [Fact]
+        public void WorkspaceReady_WhenNotOnUiThread_MarshalsOnceAndStillPopulates()
+        {
+            // Arrange
+            _dispatcher.IsOnUiThread = false;
+            var monitor = CreateMonitor("MON-1");
+
+            // Act
+            RaiseWorkspaceReady(monitor);
+
+            // Assert
+            Assert.Equal(new[] { monitor }, _viewModel.Monitors);
+            Assert.Equal(1, _dispatcher.InvokeCount);
+        }
+
+        [Fact]
+        public void WorkspaceReady_WhenOnUiThread_DoesNotUseDispatcher()
+        {
+            // Arrange
+            var monitor = CreateMonitor("MON-1");
+
+            // Act
+            RaiseWorkspaceReady(monitor);
+
+            // Assert
+            Assert.Equal(new[] { monitor }, _viewModel.Monitors);
+            Assert.Equal(0, _dispatcher.InvokeCount);
+        }
+
+        [Fact]
+        public void WorkspaceReady_ClearsLoadingFlag()
+        {
+            // Arrange
+            _viewModel.RecalculateLayout(800, 600);
+            Assert.True(_viewModel.IsLoading);
+
+            // Act
+            RaiseWorkspaceReady(CreateMonitor("MON-1"));
+
+            // Assert
+            Assert.False(_viewModel.IsLoading);
+        }
+
+        [Fact]
+        public void WorkspaceReady_WhenSelectionPreserved_RestoresSelectedMonitorByHardwareId()
+        {
+            // Arrange
+            var original = CreateMonitor("MON-1");
+            RaiseWorkspaceReady(original, CreateMonitor("MON-2", 2));
+            _viewModel.SelectMonitorCommand.Execute(original);
+            _viewModel.RecalculateLayout(800, 600);
+            var rebuilt = CreateMonitor("MON-1");
+
+            // Act
+            RaiseWorkspaceReady(CreateMonitor("MON-2", 2), rebuilt);
+
+            // Assert
+            Assert.Same(rebuilt, _viewModel.SelectedMonitor);
+            Assert.True(rebuilt.IsSelected);
+        }
+
+        [Fact]
+        public void WorkspaceReady_WhenSelectionNotPreserved_ClearsSelection()
+        {
+            // Arrange
+            var original = CreateMonitor("MON-1");
+            RaiseWorkspaceReady(original);
+            _viewModel.SelectMonitorCommand.Execute(original);
+            _viewModel.RecalculateLayout(800, 600);
+            _viewModel.RefreshMonitors(false);
+
+            // Act
+            RaiseWorkspaceReady(CreateMonitor("MON-1"));
+
+            // Assert
+            Assert.Null(_viewModel.SelectedMonitor);
+            Assert.False(_viewModel.IsMonitorSelected);
+        }
+
+        [Fact]
+        public void WorkspaceReady_WhenMonitorConfigurationChanges_MarksViewModelDirty()
+        {
+            // Arrange
+            var monitor = CreateMonitor("MON-1");
+            RaiseWorkspaceReady(monitor);
+
+            // Act
+            monitor.Configuration.DimLevel = 50;
+
+            // Assert
+            Assert.True(_viewModel.IsDirty);
+            Assert.Equal("OLED Sleeper Settings*", _viewModel.WindowTitle);
+        }
+
+        [Fact]
+        public void IsDirty_WhenSetToSameValue_RaisesNoFurtherNotification()
+        {
+            // Arrange
+            var notifications = 0;
+            _viewModel.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(MainViewModel.IsDirty)) { notifications++; }
+            };
+
+            // Act
+            _viewModel.IsDirty = true;
+            _viewModel.IsDirty = true;
+
+            // Assert
+            Assert.Equal(1, notifications);
+        }
+
+        [Fact]
+        public void SelectMonitorCommand_SelectsMonitorAndDeselectsPrevious()
+        {
+            // Arrange
+            var first = CreateMonitor("MON-1");
+            var second = CreateMonitor("MON-2", 2);
+            RaiseWorkspaceReady(first, second);
+
+            // Act
+            _viewModel.SelectMonitorCommand.Execute(first);
+            _viewModel.SelectMonitorCommand.Execute(second);
+
+            // Assert
+            Assert.Same(second, _viewModel.SelectedMonitor);
+            Assert.False(first.IsSelected);
+            Assert.True(second.IsSelected);
+            Assert.True(_viewModel.IsMonitorSelected);
+        }
+
+        [Fact]
+        public void SelectMonitorCommand_WithUnrelatedParameter_KeepsCurrentSelection()
+        {
+            // Arrange
+            var monitor = CreateMonitor("MON-1");
+            RaiseWorkspaceReady(monitor);
+            _viewModel.SelectMonitorCommand.Execute(monitor);
+
+            // Act
+            _viewModel.SelectMonitorCommand.Execute("not a monitor");
+
+            // Assert
+            Assert.Same(monitor, _viewModel.SelectedMonitor);
+        }
+
+        [Fact]
+        public void RecalculateLayout_RequestsWorkspaceBuildForNewSize()
+        {
+            // Act
+            _viewModel.RecalculateLayout(800, 600);
+
+            // Assert
+            _workspaceServiceMock.Verify(x => x.BuildWorkspaceAsync(800, 600), Times.Once);
+            Assert.True(_viewModel.IsLoading);
+        }
+
+        [Fact]
+        public void RecalculateLayout_WithNonPositiveSize_LeavesLoadingUntouched()
+        {
+            // Act
+            _viewModel.RecalculateLayout(0, 600);
+
+            // Assert
+            Assert.False(_viewModel.IsLoading);
+            _workspaceServiceMock.Verify(x => x.BuildWorkspaceAsync(0, 600), Times.Once);
+        }
+
+        [Fact]
+        public void RecalculateLayout_WhenWorkspaceTaskFaults_DoesNotThrow()
+        {
+            // Arrange
+            _workspaceServiceMock
+                .Setup(x => x.BuildWorkspaceAsync(It.IsAny<double>(), It.IsAny<double>()))
+                .Returns(Task.FromException(new InvalidOperationException("Simulated workspace failure.")));
+
+            // Act
+            var exception = Record.Exception(() => _viewModel.RecalculateLayout(800, 600));
+
+            // Assert
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void RefreshMonitors_RequestsWorkspaceRefreshForCurrentContainerSize()
+        {
+            // Arrange
+            _viewModel.RecalculateLayout(800, 600);
+
+            // Act
+            _viewModel.RefreshMonitors(false);
+
+            // Assert
+            _workspaceServiceMock.Verify(x => x.RefreshWorkspaceAsync(800, 600), Times.Once);
+            Assert.True(_viewModel.IsLoading);
+        }
+
+        [Fact]
+        public void ReloadMonitorsCommand_RequestsWorkspaceRefresh()
+        {
+            // Arrange
+            _viewModel.RecalculateLayout(800, 600);
+
+            // Act
+            _viewModel.ReloadMonitorsCommand.Execute(null);
+
+            // Assert
+            _workspaceServiceMock.Verify(x => x.RefreshWorkspaceAsync(800, 600), Times.Once);
+        }
+
+        [Fact]
+        public void DiscardChangesCommand_RefreshesWorkspacePreservingSelection()
+        {
+            // Arrange
+            var monitor = CreateMonitor("MON-1");
+            RaiseWorkspaceReady(monitor);
+            _viewModel.SelectMonitorCommand.Execute(monitor);
+            _viewModel.RecalculateLayout(800, 600);
+
+            // Act
+            _viewModel.DiscardChangesCommand.Execute(null);
+            var rebuilt = CreateMonitor("MON-1");
+            RaiseWorkspaceReady(rebuilt);
+
+            // Assert
+            _workspaceServiceMock.Verify(x => x.RefreshWorkspaceAsync(800, 600), Times.Once);
+            Assert.Same(rebuilt, _viewModel.SelectedMonitor);
+        }
+
+        [Fact]
+        public void OnWindowClosing_WhenNotDirty_HidesMainWindowAndReturnsFalse()
+        {
+            // Act
+            var shouldClose = _viewModel.OnWindowClosing();
+
+            // Assert
+            Assert.False(shouldClose);
+            _mainWindowAccessorMock.Verify(x => x.HideMainWindow(), Times.Once);
+        }
+
+        [Fact]
+        public void SaveSettingsCommand_WhenSettingsValid_SavesAndClearsDirtyState()
+        {
+            // Arrange
+            var monitor = CreateMonitor("MON-1");
+            RaiseWorkspaceReady(monitor);
+            monitor.Configuration.DimLevel = 50;
+            Assert.True(_viewModel.IsDirty);
+
+            List<MonitorSettings>? saved = null;
+            _settingsServiceMock
+                .Setup(x => x.SaveSettings(It.IsAny<List<MonitorSettings>>()))
+                .Callback<List<MonitorSettings>>(settings => saved = settings);
+
+            // Act
+            _viewModel.SaveSettingsCommand.Execute(null);
+
+            // Assert
+            Assert.NotNull(saved);
+            var entry = Assert.Single(saved!);
+            Assert.Equal("MON-1", entry.HardwareId);
+            Assert.Equal(50, entry.DimLevel);
+            Assert.False(_viewModel.IsDirty);
+            Assert.Equal("Saved!", _viewModel.SaveButtonText);
+        }
+
+        /// <summary>
+        /// Builds a layout view model over a 1920x1080 monitor with the supplied hardware ID.
+        /// </summary>
+        private static MonitorLayoutViewModel CreateMonitor(string hardwareId, int displayNumber = 1)
+        {
+            var bounds = new Rect(0, 0, 1920, 1080);
+            var monitorInfo = new MonitorInfo
+            {
+                HardwareId = hardwareId,
+                DisplayNumber = displayNumber,
+                DeviceName = $@"\\.\DISPLAY{displayNumber}",
+                Bounds = bounds
+            };
+
+            return new MonitorLayoutViewModel(monitorInfo, 1.0, bounds, 0, 0);
+        }
+
+        /// <summary>
+        /// Raises WorkspaceReady with the supplied monitors, as the workspace service does once a build finishes.
+        /// </summary>
+        private void RaiseWorkspaceReady(params MonitorLayoutViewModel[] monitors)
+        {
+            _workspaceServiceMock.Raise(
+                x => x.WorkspaceReady += null,
+                this,
+                new ObservableCollection<MonitorLayoutViewModel>(monitors));
+        }
+    }
+}

--- a/OLED-Sleeper/Infrastructure/ServiceConfigurator.cs
+++ b/OLED-Sleeper/Infrastructure/ServiceConfigurator.cs
@@ -73,6 +73,7 @@ namespace OLED_Sleeper.Infrastructure
             services.AddSingleton<MainWindow>();
             services.AddSingleton<ITrayIconService, TrayIconService>();
             services.AddSingleton<IMainWindowService, MainWindowService>();
+            services.AddSingleton<IDialogService, MessageBoxDialogService>();
             services.AddSingleton<IApplicationInstanceManager>(_ => instanceManager);
 
             return services.BuildServiceProvider();

--- a/OLED-Sleeper/UI/Helpers/MonitorSettingsValidator.cs
+++ b/OLED-Sleeper/UI/Helpers/MonitorSettingsValidator.cs
@@ -1,31 +1,24 @@
 ﻿using OLED_Sleeper.UI.ViewModels;
 using System.Text;
-using System.Windows;
 
 namespace OLED_Sleeper.UI.Helpers
 {
     /// <summary>
-    /// Provides validation logic for monitor settings and displays errors to the user.
+    /// Provides validation logic for monitor settings.
     /// This is a static helper class and does not hold any state.
     /// </summary>
     public static class MonitorSettingsValidator
     {
         /// <summary>
-        /// Validates the provided monitor settings and displays a message box if there are invalid monitors.
+        /// Validates the provided monitor settings.
         /// </summary>
         /// <param name="monitors">The collection of monitor layout view models to validate.</param>
-        /// <returns>True if all monitors are valid; otherwise, false.</returns>
-        public static bool ValidateAndNotify(IEnumerable<MonitorLayoutViewModel> monitors)
+        /// <returns>An error message describing every invalid monitor, or null when all are valid.</returns>
+        public static string? BuildValidationError(IEnumerable<MonitorLayoutViewModel> monitors)
         {
             var invalidMonitors = GetInvalidMonitors(monitors);
 
-            if (invalidMonitors.Any())
-            {
-                ShowValidationError(invalidMonitors);
-                return false;
-            }
-
-            return true;
+            return invalidMonitors.Count > 0 ? BuildMessage(invalidMonitors) : null;
         }
 
         /// <summary>
@@ -41,10 +34,11 @@ namespace OLED_Sleeper.UI.Helpers
         }
 
         /// <summary>
-        /// Displays a validation error message for the provided invalid monitors.
+        /// Builds the validation error message for the provided invalid monitors.
         /// </summary>
         /// <param name="invalidMonitors">The list of invalid monitor view models.</param>
-        private static void ShowValidationError(List<MonitorLayoutViewModel> invalidMonitors)
+        /// <returns>The assembled error message.</returns>
+        private static string BuildMessage(List<MonitorLayoutViewModel> invalidMonitors)
         {
             var errorBuilder = new StringBuilder();
             errorBuilder.AppendLine("One or more monitors have configuration issues and cannot be saved:");
@@ -60,7 +54,8 @@ namespace OLED_Sleeper.UI.Helpers
                     errorBuilder.AppendLine($"     • {config.ActiveConditionsError}");
             }
             errorBuilder.AppendLine("\nTo resolve these issues, either update the highlighted fields or uncheck 'Manage' for the affected monitor(s).");
-            MessageBox.Show(errorBuilder.ToString(), "Monitor Configuration Error", MessageBoxButton.OK, MessageBoxImage.Error);
+
+            return errorBuilder.ToString();
         }
     }
 }

--- a/OLED-Sleeper/UI/Services/Interfaces/IDialogService.cs
+++ b/OLED-Sleeper/UI/Services/Interfaces/IDialogService.cs
@@ -1,0 +1,26 @@
+using System.Windows;
+
+namespace OLED_Sleeper.UI.Services.Interfaces
+{
+    /// <summary>
+    /// Defines the contract for showing a modal dialog to the user.
+    /// Every member blocks until the user answers and must be called on the UI thread.
+    /// </summary>
+    public interface IDialogService
+    {
+        /// <summary>
+        /// Asks a question with Yes, No and Cancel buttons.
+        /// </summary>
+        /// <param name="message">The question to show.</param>
+        /// <param name="caption">The dialog's title.</param>
+        /// <returns>The button the user chose.</returns>
+        MessageBoxResult AskYesNoCancel(string message, string caption);
+
+        /// <summary>
+        /// Shows an error the user can only acknowledge.
+        /// </summary>
+        /// <param name="message">The error to show.</param>
+        /// <param name="caption">The dialog's title.</param>
+        void ShowError(string message, string caption);
+    }
+}

--- a/OLED-Sleeper/UI/Services/MessageBoxDialogService.cs
+++ b/OLED-Sleeper/UI/Services/MessageBoxDialogService.cs
@@ -1,0 +1,21 @@
+using OLED_Sleeper.UI.Services.Interfaces;
+using System.Diagnostics.CodeAnalysis;
+using System.Windows;
+
+namespace OLED_Sleeper.UI.Services
+{
+    /// <summary>
+    /// Shows dialogs through <see cref="MessageBox"/>.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class MessageBoxDialogService : IDialogService
+    {
+        /// <inheritdoc />
+        public MessageBoxResult AskYesNoCancel(string message, string caption) =>
+            MessageBox.Show(message, caption, MessageBoxButton.YesNoCancel, MessageBoxImage.Warning);
+
+        /// <inheritdoc />
+        public void ShowError(string message, string caption) =>
+            MessageBox.Show(message, caption, MessageBoxButton.OK, MessageBoxImage.Error);
+    }
+}

--- a/OLED-Sleeper/UI/ViewModels/MainViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MainViewModel.cs
@@ -40,6 +40,11 @@ namespace OLED_Sleeper.UI.ViewModels
         private readonly IMainWindowAccessor _mainWindowAccessor;
 
         /// <summary>
+        /// Shows modal dialogs to the user.
+        /// </summary>
+        private readonly IDialogService _dialogService;
+
+        /// <summary>
         /// The width of the container used for monitor layout calculations.
         /// </summary>
         private double _containerWidth;
@@ -184,12 +189,14 @@ namespace OLED_Sleeper.UI.ViewModels
             IWorkspaceService workspaceService,
             IMonitorSettingsFileService settingsService,
             IDispatcher dispatcher,
-            IMainWindowAccessor mainWindowAccessor)
+            IMainWindowAccessor mainWindowAccessor,
+            IDialogService dialogService)
         {
             _workspaceService = workspaceService;
             _settingsService = settingsService;
             _dispatcher = dispatcher;
             _mainWindowAccessor = mainWindowAccessor;
+            _dialogService = dialogService;
 
             SelectMonitorCommand = new RelayCommand(ExecuteSelectMonitor);
             ReloadMonitorsCommand = new RelayCommand(() => RefreshMonitors(false));
@@ -231,7 +238,7 @@ namespace OLED_Sleeper.UI.ViewModels
         private static void ObserveWorkspaceTask(Task task)
         {
             _ = task.ContinueWith(
-                faulted => Log.Error(faulted.Exception?.GetBaseException(), "Failed to build the monitor workspace."),
+                faulted => Log.Error(faulted.Exception!.GetBaseException(), "Failed to build the monitor workspace."),
                 CancellationToken.None,
                 TaskContinuationOptions.OnlyOnFaulted,
                 TaskScheduler.Default);
@@ -245,11 +252,9 @@ namespace OLED_Sleeper.UI.ViewModels
         {
             if (IsDirty)
             {
-                var result = MessageBox.Show(
+                var result = _dialogService.AskYesNoCancel(
                     "You have unsaved changes. Would you like to save them before hiding the window?",
-                    "Unsaved Changes",
-                    MessageBoxButton.YesNoCancel,
-                    MessageBoxImage.Warning);
+                    "Unsaved Changes");
 
                 if (result == MessageBoxResult.Cancel)
                 {
@@ -311,12 +316,16 @@ namespace OLED_Sleeper.UI.ViewModels
         // --- Save Process Helpers ---
 
         /// <summary>
-        /// Validates all monitor settings using the save validation service.
+        /// Validates all monitor settings, telling the user about any that cannot be saved.
         /// </summary>
         /// <returns>True if all monitors are valid; otherwise, false.</returns>
         private bool ValidateSettings()
         {
-            return MonitorSettingsValidator.ValidateAndNotify(Monitors);
+            var error = MonitorSettingsValidator.BuildValidationError(Monitors);
+            if (error == null) return true;
+
+            _dialogService.ShowError(error, "Monitor Configuration Error");
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
`MainViewModel` gets 26 tests, and modal dialogs move behind `IDialogService`.

* `MessageBoxDialogService` is excluded from coverage, so nothing automated proves the dialogs still render. Worth one manual pass: Cancel keeps the window open, Yes saves and hides, No discards and hides.
* `ProvideSaveFeedbackAsync` runs its tail after `await Task.Delay(2000)` on an `async void` command, so it is reached only because later tests keep the process alive. A coverage dip there is not a regression.
* `MonitorSettingsValidator.ValidateAndNotify` becomes `BuildValidationError(monitors) -> string?`; the view model shows the message it returns.
* `ObserveWorkspaceTask` uses `faulted.Exception!` instead of `?.`, since `OnlyOnFaulted` guarantees the exception is present.
* No user-visible change: the same prompts, buttons and icons appear at the same moments.
* Suite goes from 22 tests to 51.
