### PR TITLE
refactor: split the monitor dimming service and cover it with tests

### DIFF
--- a/OLED-Sleeper.Tests/Features/MonitorDimming/Handlers/ApplyDimCommandHandlerTests.cs
+++ b/OLED-Sleeper.Tests/Features/MonitorDimming/Handlers/ApplyDimCommandHandlerTests.cs
@@ -1,0 +1,51 @@
+using Moq;
+using OLED_Sleeper.Features.MonitorDimming.Commands;
+using OLED_Sleeper.Features.MonitorDimming.Handlers;
+using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
+
+namespace OLED_Sleeper.Tests.Features.MonitorDimming.Handlers
+{
+    public class ApplyDimCommandHandlerTests
+    {
+        private const string HardwareId = "MON-123";
+
+        private readonly Mock<IMonitorDimmingService> _monitorDimmingServiceMock;
+        private readonly ApplyDimCommandHandler _handler;
+
+        public ApplyDimCommandHandlerTests()
+        {
+            _monitorDimmingServiceMock = new Mock<IMonitorDimmingService>();
+            _handler = new ApplyDimCommandHandler(_monitorDimmingServiceMock.Object);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenCommandIsHandled_DimsTheMonitorAtTheCommandedLevel()
+        {
+            // Arrange
+            var command = new ApplyDimCommand { HardwareId = HardwareId, DimLevel = 15 };
+
+            // Act
+            await _handler.HandleAsync(command);
+
+            // Assert
+            _monitorDimmingServiceMock.Verify(x => x.DimMonitorAsync(HardwareId, 15), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenTheServiceThrows_SwallowsTheException()
+        {
+            // Arrange
+            var command = new ApplyDimCommand { HardwareId = HardwareId, DimLevel = 15 };
+            _monitorDimmingServiceMock
+                .Setup(x => x.DimMonitorAsync(HardwareId, 15))
+                .ThrowsAsync(new Exception("Simulated failure"));
+
+            // Act
+            var exception = await Record.ExceptionAsync(() => _handler.HandleAsync(command));
+
+            // Assert
+            Assert.Null(exception);
+            _monitorDimmingServiceMock.Verify(x => x.DimMonitorAsync(HardwareId, 15), Times.Once);
+        }
+    }
+}

--- a/OLED-Sleeper.Tests/Features/MonitorDimming/Handlers/ApplyUndimCommandHandlerTests.cs
+++ b/OLED-Sleeper.Tests/Features/MonitorDimming/Handlers/ApplyUndimCommandHandlerTests.cs
@@ -1,0 +1,51 @@
+using Moq;
+using OLED_Sleeper.Features.MonitorDimming.Commands;
+using OLED_Sleeper.Features.MonitorDimming.Handlers;
+using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
+
+namespace OLED_Sleeper.Tests.Features.MonitorDimming.Handlers
+{
+    public class ApplyUndimCommandHandlerTests
+    {
+        private const string HardwareId = "MON-123";
+
+        private readonly Mock<IMonitorDimmingService> _monitorDimmingServiceMock;
+        private readonly ApplyUndimCommandHandler _handler;
+
+        public ApplyUndimCommandHandlerTests()
+        {
+            _monitorDimmingServiceMock = new Mock<IMonitorDimmingService>();
+            _handler = new ApplyUndimCommandHandler(_monitorDimmingServiceMock.Object);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenCommandIsHandled_UndimsTheMonitor()
+        {
+            // Arrange
+            var command = new ApplyUndimCommand { HardwareId = HardwareId };
+
+            // Act
+            await _handler.HandleAsync(command);
+
+            // Assert
+            _monitorDimmingServiceMock.Verify(x => x.UndimMonitorAsync(HardwareId), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenTheServiceThrows_SwallowsTheException()
+        {
+            // Arrange
+            var command = new ApplyUndimCommand { HardwareId = HardwareId };
+            _monitorDimmingServiceMock
+                .Setup(x => x.UndimMonitorAsync(HardwareId))
+                .ThrowsAsync(new Exception("Simulated failure"));
+
+            // Act
+            var exception = await Record.ExceptionAsync(() => _handler.HandleAsync(command));
+
+            // Assert
+            Assert.Null(exception);
+            _monitorDimmingServiceMock.Verify(x => x.UndimMonitorAsync(HardwareId), Times.Once);
+        }
+    }
+}

--- a/OLED-Sleeper.Tests/Features/MonitorDimming/Handlers/RestoreBrightnessOnAllMonitorsCommandHandlerTests.cs
+++ b/OLED-Sleeper.Tests/Features/MonitorDimming/Handlers/RestoreBrightnessOnAllMonitorsCommandHandlerTests.cs
@@ -1,0 +1,74 @@
+using Moq;
+using OLED_Sleeper.Features.MonitorDimming.Commands;
+using OLED_Sleeper.Features.MonitorDimming.Handlers;
+using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
+
+namespace OLED_Sleeper.Tests.Features.MonitorDimming.Handlers
+{
+    public class RestoreBrightnessOnAllMonitorsCommandHandlerTests
+    {
+        private const string HardwareId = "MON-123";
+        private const string SecondHardwareId = "MON-456";
+
+        private readonly Mock<IMonitorDimmingService> _monitorDimmingServiceMock;
+        private readonly RestoreBrightnessOnAllMonitorsCommandHandler _handler;
+
+        public RestoreBrightnessOnAllMonitorsCommandHandlerTests()
+        {
+            _monitorDimmingServiceMock = new Mock<IMonitorDimmingService>();
+            _handler = new RestoreBrightnessOnAllMonitorsCommandHandler(_monitorDimmingServiceMock.Object);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenNoMonitorIsDimmed_UndimsNothing()
+        {
+            // Arrange
+            SetupDimmedMonitors(new Dictionary<string, uint>());
+
+            // Act
+            await _handler.HandleAsync(new RestoreBrightnessOnAllMonitorsCommand());
+
+            // Assert
+            _monitorDimmingServiceMock.Verify(x => x.UndimMonitorAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenMonitorsAreDimmed_UndimsEveryOne()
+        {
+            // Arrange
+            SetupDimmedMonitors(new Dictionary<string, uint> { [HardwareId] = 80, [SecondHardwareId] = 60 });
+
+            // Act
+            await _handler.HandleAsync(new RestoreBrightnessOnAllMonitorsCommand());
+
+            // Assert
+            _monitorDimmingServiceMock.Verify(x => x.UndimMonitorAsync(HardwareId), Times.Once);
+            _monitorDimmingServiceMock.Verify(x => x.UndimMonitorAsync(SecondHardwareId), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenTheServiceThrows_PropagatesTheException()
+        {
+            // Arrange
+            SetupDimmedMonitors(new Dictionary<string, uint> { [HardwareId] = 80 });
+            _monitorDimmingServiceMock
+                .Setup(x => x.UndimMonitorAsync(HardwareId))
+                .ThrowsAsync(new Exception("Simulated failure"));
+
+            // Act
+            var exception = await Record.ExceptionAsync(() => _handler.HandleAsync(new RestoreBrightnessOnAllMonitorsCommand()));
+
+            // Assert
+            Assert.NotNull(exception);
+        }
+
+        /// <summary>
+        /// Makes GetDimmedMonitors() return the supplied recordings.
+        /// </summary>
+        /// <param name="recordings">The map from hardware ID to raw pre-dim brightness.</param>
+        private void SetupDimmedMonitors(Dictionary<string, uint> recordings)
+        {
+            _monitorDimmingServiceMock.Setup(x => x.GetDimmedMonitors()).Returns(recordings);
+        }
+    }
+}

--- a/OLED-Sleeper.Tests/Features/MonitorDimming/Helpers/BrightnessScaleTests.cs
+++ b/OLED-Sleeper.Tests/Features/MonitorDimming/Helpers/BrightnessScaleTests.cs
@@ -1,0 +1,63 @@
+using OLED_Sleeper.Features.MonitorDimming.Helpers;
+
+namespace OLED_Sleeper.Tests.Features.MonitorDimming.Helpers
+{
+    public class BrightnessScaleTests
+    {
+        [Theory]
+        [InlineData(0, 0u)]
+        [InlineData(15, 38u)]
+        [InlineData(80, 204u)]
+        [InlineData(100, 255u)]
+        public void ToRawBrightness_WhenMonitorHasItsOwnRange_ScalesThePercentageOntoIt(int dimLevelPercentage, uint expected)
+        {
+            // Act
+            var raw = BrightnessScale.ToRawBrightness(dimLevelPercentage, 255);
+
+            // Assert
+            Assert.Equal(expected, raw);
+        }
+
+        [Fact]
+        public void ToRawBrightness_WhenMonitorReportedNoRange_ReturnsThePercentageUnchanged()
+        {
+            // Act
+            var raw = BrightnessScale.ToRawBrightness(15, 0);
+
+            // Assert
+            Assert.Equal(15u, raw);
+        }
+
+        [Fact]
+        public void ToRawBrightness_WhenMonitorRunsOnThePercentageScale_ReturnsThePercentageUnchanged()
+        {
+            // Act
+            var raw = BrightnessScale.ToRawBrightness(15, 100);
+
+            // Assert
+            Assert.Equal(15u, raw);
+        }
+
+        [Fact]
+        public void ToRawBrightness_WhenTheScaledValueLandsOnAHalf_RoundsAwayFromZero()
+        {
+            // Act
+            var raw = BrightnessScale.ToRawBrightness(50, 255);
+
+            // Assert
+            Assert.Equal(128u, raw);
+        }
+
+        [Theory]
+        [InlineData(-10, 0u)]
+        [InlineData(150, 255u)]
+        public void ToRawBrightness_WhenTheDimLevelIsOutsideThePercentageScale_ClampsIt(int dimLevelPercentage, uint expected)
+        {
+            // Act
+            var raw = BrightnessScale.ToRawBrightness(dimLevelPercentage, 255);
+
+            // Assert
+            Assert.Equal(expected, raw);
+        }
+    }
+}

--- a/OLED-Sleeper.Tests/Features/MonitorDimming/Services/MonitorDimmingServiceTests.cs
+++ b/OLED-Sleeper.Tests/Features/MonitorDimming/Services/MonitorDimmingServiceTests.cs
@@ -1,0 +1,339 @@
+using Moq;
+using OLED_Sleeper.Features.MonitorDimming.Services;
+using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
+using OLED_Sleeper.Features.MonitorInformation.Models;
+using OLED_Sleeper.Features.MonitorInformation.Services.Interfaces;
+using OLED_Sleeper.Tests.TestDoubles;
+
+namespace OLED_Sleeper.Tests.Features.MonitorDimming.Services
+{
+    public class MonitorDimmingServiceTests
+    {
+        private const string HardwareId = "MON-PRIMARY";
+        private const string DeviceName = @"\\.\DISPLAY1";
+        private const string SecondHardwareId = "MON-SECOND";
+        private const string SecondDeviceName = @"\\.\DISPLAY2";
+
+        private readonly Mock<IMonitorInfoManager> _monitorManager;
+        private readonly Mock<IOriginalBrightnessStore> _store;
+        private readonly FakeDdcCiAccess _ddcCiAccess;
+        private readonly FakeDdcCiSession _panel;
+        private readonly FakeDdcCiSession _secondPanel;
+        private readonly MonitorDimmingService _service;
+
+        public MonitorDimmingServiceTests()
+        {
+            _monitorManager = new Mock<IMonitorInfoManager>();
+            _store = new Mock<IOriginalBrightnessStore>();
+            _ddcCiAccess = new FakeDdcCiAccess();
+
+            SetupMonitors(
+                CreateMonitor(HardwareId, DeviceName, 255),
+                CreateMonitor(SecondHardwareId, SecondDeviceName, 255));
+
+            _panel = _ddcCiAccess.AddPanel(DeviceName, 80);
+            _secondPanel = _ddcCiAccess.AddPanel(SecondDeviceName, 80);
+
+            _service = new MonitorDimmingService(_monitorManager.Object, _ddcCiAccess, _store.Object);
+        }
+
+        [Fact]
+        public async Task DimMonitorAsync_WhenMonitorIsReachable_RecordsTheCurrentBrightnessBeforeWritingTheScaledValue()
+        {
+            // Arrange
+            var recordedBeforeAnyWrite = false;
+            _store.Setup(s => s.RecordOriginal(HardwareId, 80u))
+                .Callback(() => recordedBeforeAnyWrite = _panel.WrittenBrightnessLevels.Count == 0);
+
+            // Act
+            await _service.DimMonitorAsync(HardwareId, 15);
+
+            // Assert
+            _store.Verify(s => s.RecordOriginal(HardwareId, 80u), Times.Once);
+            Assert.True(recordedBeforeAnyWrite);
+            Assert.Equal(new[] { 38u }, _panel.WrittenBrightnessLevels);
+        }
+
+        [Fact]
+        public async Task DimMonitorAsync_WhenTheBrightnessReadFails_RecordsNothingAndWritesNothing()
+        {
+            // Arrange
+            _panel.ReadsFail = true;
+
+            // Act
+            await _service.DimMonitorAsync(HardwareId, 15);
+
+            // Assert
+            _store.Verify(s => s.RecordOriginal(It.IsAny<string>(), It.IsAny<uint>()), Times.Never);
+            Assert.Empty(_panel.WrittenBrightnessLevels);
+        }
+
+        [Fact]
+        public async Task DimMonitorAsync_WhenMonitorReportedNoRange_WritesThePercentageUnscaled()
+        {
+            // Arrange
+            SetupMonitors(CreateMonitor(HardwareId, DeviceName, 0));
+
+            // Act
+            await _service.DimMonitorAsync(HardwareId, 15);
+
+            // Assert
+            Assert.Equal(new[] { 15u }, _panel.WrittenBrightnessLevels);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task DimMonitorAsync_WhenHardwareIdIsMissing_OpensNoChannel(string? hardwareId)
+        {
+            // Act
+            await _service.DimMonitorAsync(hardwareId, 15);
+
+            // Assert
+            Assert.Empty(_ddcCiAccess.OpenAttempts);
+        }
+
+        [Fact]
+        public async Task DimMonitorAsync_WhenMonitorIsNotAttached_OpensNoChannel()
+        {
+            // Act
+            await _service.DimMonitorAsync("MON-UNKNOWN", 15);
+
+            // Assert
+            Assert.Empty(_ddcCiAccess.OpenAttempts);
+        }
+
+        [Fact]
+        public async Task UndimMonitorAsync_WhenMonitorHasNoRecording_OpensNoChannel()
+        {
+            // Act
+            await _service.UndimMonitorAsync(HardwareId);
+
+            // Assert
+            Assert.Empty(_ddcCiAccess.OpenAttempts);
+        }
+
+        [Fact]
+        public async Task UndimMonitorAsync_WhenTheRestoreIsConfirmed_WritesTheRawOriginalAndClearsTheRecording()
+        {
+            // Arrange
+            SetupRecording(HardwareId, 80);
+
+            // Act
+            await _service.UndimMonitorAsync(HardwareId);
+
+            // Assert
+            Assert.Equal(new[] { 80u }, _panel.WrittenBrightnessLevels);
+            _store.Verify(s => s.RemoveOriginal(HardwareId), Times.Once);
+        }
+
+        [Fact]
+        public async Task UndimMonitorAsync_WhenTheReadBackIsWithinTolerance_ConfirmsTheRestore()
+        {
+            // Arrange
+            SetupRecording(HardwareId, 80);
+            _panel.ReadBackOverride = 82;
+
+            // Act
+            await _service.UndimMonitorAsync(HardwareId);
+
+            // Assert
+            _store.Verify(s => s.RemoveOriginal(HardwareId), Times.Once);
+        }
+
+        [Fact]
+        public async Task UndimMonitorAsync_WhenTheReadBackIsOutsideTolerance_RetriesAndKeepsTheRecording()
+        {
+            // Arrange
+            SetupRecording(HardwareId, 80);
+            _panel.ReadBackOverride = 83;
+
+            // Act
+            await _service.UndimMonitorAsync(HardwareId);
+
+            // Assert
+            Assert.Equal(3, _panel.WrittenBrightnessLevels.Count);
+            _store.Verify(s => s.RemoveOriginal(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task UndimMonitorAsync_WhenTheWriteIsRejected_RetriesThreeTimesAndKeepsTheRecording()
+        {
+            // Arrange
+            SetupRecording(HardwareId, 80);
+            _panel.WritesAreRejected = true;
+
+            // Act
+            await _service.UndimMonitorAsync(HardwareId);
+
+            // Assert
+            Assert.Equal(3, _panel.WrittenBrightnessLevels.Count);
+            _store.Verify(s => s.RemoveOriginal(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task UndimMonitorAsync_WhenMonitorIsUnreachable_KeepsTheRecordingWithoutRetrying()
+        {
+            // Arrange
+            const string unreachableHardwareId = "MON-OFF";
+            SetupMonitors(CreateMonitor(unreachableHardwareId, @"\\.\DISPLAY9", 255));
+            SetupRecording(unreachableHardwareId, 80);
+
+            // Act
+            await _service.UndimMonitorAsync(unreachableHardwareId);
+
+            // Assert
+            Assert.Single(_ddcCiAccess.OpenAttempts);
+            _store.Verify(s => s.RemoveOriginal(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task UndimMonitorAsync_WhenEveryAttemptFails_DisposesEveryChannelItOpened()
+        {
+            // Arrange
+            SetupRecording(HardwareId, 80);
+            _panel.WritesAreRejected = true;
+
+            // Act
+            await _service.UndimMonitorAsync(HardwareId);
+
+            // Assert
+            Assert.Equal(3, _ddcCiAccess.OpenAttempts.Count);
+            Assert.Equal(3, _panel.DisposeCount);
+        }
+
+        [Fact]
+        public void GetDimmedMonitors_WhenCalled_ReturnsWhatTheStoreHolds()
+        {
+            // Arrange
+            var recordings = new Dictionary<string, uint> { [HardwareId] = 80 };
+            _store.Setup(s => s.GetAll()).Returns(recordings);
+
+            // Act
+            var dimmed = _service.GetDimmedMonitors();
+
+            // Assert
+            Assert.Equal(recordings, dimmed);
+        }
+
+        [Fact]
+        public async Task DimMonitorAsync_WhenTheSameMonitorIsBusy_WaitsForTheGate()
+        {
+            // Arrange
+            using var release = new ManualResetEventSlim();
+            var reachedPanel = HoldTheFirstChannelOpen(release);
+            var first = Task.Run(() => _service.DimMonitorAsync(HardwareId, 15));
+            await reachedPanel.Task;
+
+            // Act
+            var second = Task.Run(() => _service.DimMonitorAsync(HardwareId, 15));
+            await Task.Delay(100);
+
+            // Assert
+            Assert.Single(_ddcCiAccess.OpenAttempts);
+            Assert.False(second.IsCompleted);
+            release.Set();
+            await first;
+            await second;
+        }
+
+        [Fact]
+        public async Task UndimMonitorAsync_WhenADimIsInFlightOnTheSameMonitor_WaitsForTheGate()
+        {
+            // Arrange
+            SetupRecording(HardwareId, 80);
+            using var release = new ManualResetEventSlim();
+            var reachedPanel = HoldTheFirstChannelOpen(release);
+            var dim = Task.Run(() => _service.DimMonitorAsync(HardwareId, 15));
+            await reachedPanel.Task;
+
+            // Act
+            var undim = Task.Run(() => _service.UndimMonitorAsync(HardwareId));
+            await Task.Delay(100);
+
+            // Assert
+            Assert.Single(_ddcCiAccess.OpenAttempts);
+            Assert.False(undim.IsCompleted);
+            release.Set();
+            await dim;
+            await undim;
+            Assert.Equal(new[] { 38u, 80u }, _panel.WrittenBrightnessLevels);
+        }
+
+        [Fact]
+        public async Task DimMonitorAsync_WhenADifferentMonitorIsBusy_RunsWithoutWaiting()
+        {
+            // Arrange
+            using var release = new ManualResetEventSlim();
+            var reachedPanel = HoldTheFirstChannelOpen(release);
+            var first = Task.Run(() => _service.DimMonitorAsync(HardwareId, 15));
+            await reachedPanel.Task;
+
+            // Act
+            await _service.DimMonitorAsync(SecondHardwareId, 15);
+
+            // Assert
+            Assert.Equal(new[] { 38u }, _secondPanel.WrittenBrightnessLevels);
+            release.Set();
+            await first;
+        }
+
+        /// <summary>
+        /// Builds an attached, DDC/CI-capable monitor.
+        /// </summary>
+        /// <param name="hardwareId">The hardware ID the service keys everything on.</param>
+        /// <param name="deviceName">The device name the channel is opened against.</param>
+        /// <param name="maxBrightness">The monitor's highest accepted brightness value.</param>
+        /// <returns>The monitor.</returns>
+        private static MonitorInfo CreateMonitor(string hardwareId, string deviceName, uint maxBrightness)
+        {
+            return new MonitorInfo
+            {
+                HardwareId = hardwareId,
+                DeviceName = deviceName,
+                MaxBrightness = maxBrightness,
+                IsDdcCiSupported = true
+            };
+        }
+
+        /// <summary>
+        /// Makes GetCurrentMonitorsAsync() return the supplied monitors, replacing any earlier list.
+        /// </summary>
+        /// <param name="monitors">The monitors to report as attached.</param>
+        private void SetupMonitors(params MonitorInfo[] monitors)
+        {
+            _monitorManager.Setup(m => m.GetCurrentMonitorsAsync()).ReturnsAsync(monitors);
+        }
+
+        /// <summary>
+        /// Makes the store report a recorded pre-dim brightness for the given monitor.
+        /// </summary>
+        /// <param name="hardwareId">The hardware ID of the monitor.</param>
+        /// <param name="brightness">The raw brightness value to report as recorded.</param>
+        private void SetupRecording(string hardwareId, uint brightness)
+        {
+            var recorded = brightness;
+            _store.Setup(s => s.TryGetOriginal(hardwareId, out recorded)).Returns(true);
+        }
+
+        /// <summary>
+        /// Blocks inside the primary monitor's channel until the event is set, so its gate stays held
+        /// while the test starts a second operation.
+        /// </summary>
+        /// <param name="release">The event that lets the held operation finish.</param>
+        /// <returns>A task that completes once the operation is inside the channel.</returns>
+        private TaskCompletionSource HoldTheFirstChannelOpen(ManualResetEventSlim release)
+        {
+            var reachedPanel = new TaskCompletionSource();
+            _ddcCiAccess.OnOpen = deviceName =>
+            {
+                if (deviceName != DeviceName) return;
+
+                reachedPanel.TrySetResult();
+                release.Wait();
+            };
+
+            return reachedPanel;
+        }
+    }
+}

--- a/OLED-Sleeper.Tests/Features/MonitorDimming/Services/MonitorDimmingServiceTests.cs
+++ b/OLED-Sleeper.Tests/Features/MonitorDimming/Services/MonitorDimmingServiceTests.cs
@@ -94,6 +94,21 @@ namespace OLED_Sleeper.Tests.Features.MonitorDimming.Services
         }
 
         [Fact]
+        public async Task DimMonitorAsync_WhenTheWriteIsRejected_KeepsTheRecordingWithoutRetrying()
+        {
+            // Arrange
+            _panel.WritesAreRejected = true;
+
+            // Act
+            await _service.DimMonitorAsync(HardwareId, 15);
+
+            // Assert
+            _store.Verify(s => s.RecordOriginal(HardwareId, 80u), Times.Once);
+            Assert.Equal(new[] { 38u }, _panel.WrittenBrightnessLevels);
+            Assert.Single(_ddcCiAccess.OpenAttempts);
+        }
+
+        [Fact]
         public async Task DimMonitorAsync_WhenMonitorIsNotAttached_OpensNoChannel()
         {
             // Act
@@ -101,6 +116,33 @@ namespace OLED_Sleeper.Tests.Features.MonitorDimming.Services
 
             // Assert
             Assert.Empty(_ddcCiAccess.OpenAttempts);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task UndimMonitorAsync_WhenHardwareIdIsMissing_OpensNoChannel(string? hardwareId)
+        {
+            // Act
+            await _service.UndimMonitorAsync(hardwareId!);
+
+            // Assert
+            Assert.Empty(_ddcCiAccess.OpenAttempts);
+        }
+
+        [Fact]
+        public async Task UndimMonitorAsync_WhenTheReadBackIsUnanswered_RetriesAndKeepsTheRecording()
+        {
+            // Arrange
+            SetupRecording(HardwareId, 80);
+            _panel.ReadsFail = true;
+
+            // Act
+            await _service.UndimMonitorAsync(HardwareId);
+
+            // Assert
+            Assert.Equal(new[] { 80u, 80u, 80u }, _panel.WrittenBrightnessLevels);
+            _store.Verify(s => s.RemoveOriginal(It.IsAny<string>()), Times.Never);
         }
 
         [Fact]

--- a/OLED-Sleeper.Tests/Features/MonitorDimming/Services/OriginalBrightnessStoreTests.cs
+++ b/OLED-Sleeper.Tests/Features/MonitorDimming/Services/OriginalBrightnessStoreTests.cs
@@ -1,0 +1,119 @@
+using Moq;
+using OLED_Sleeper.Features.MonitorDimming.Services;
+using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
+
+namespace OLED_Sleeper.Tests.Features.MonitorDimming.Services
+{
+    public class OriginalBrightnessStoreTests
+    {
+        private const string HardwareId = "MON-PRIMARY";
+
+        private readonly Mock<IMonitorBrightnessStateService> _stateService;
+
+        public OriginalBrightnessStoreTests()
+        {
+            _stateService = new Mock<IMonitorBrightnessStateService>();
+            _stateService.Setup(s => s.LoadState()).Returns(new Dictionary<string, uint>());
+        }
+
+        [Fact]
+        public void Constructor_WhenBuilt_LoadsTheRecordingsFromDisk()
+        {
+            // Arrange
+            _stateService.Setup(s => s.LoadState()).Returns(new Dictionary<string, uint> { [HardwareId] = 80 });
+
+            // Act
+            var store = new OriginalBrightnessStore(_stateService.Object);
+
+            // Assert
+            Assert.True(store.TryGetOriginal(HardwareId, out var brightness));
+            Assert.Equal(80u, brightness);
+        }
+
+        [Fact]
+        public void TryGetOriginal_WhenMonitorHasNoRecording_ReturnsFalse()
+        {
+            // Arrange
+            var store = new OriginalBrightnessStore(_stateService.Object);
+
+            // Act
+            var found = store.TryGetOriginal(HardwareId, out _);
+
+            // Assert
+            Assert.False(found);
+        }
+
+        [Fact]
+        public void RecordOriginal_WhenMonitorHasNoRecording_RecordsItAndSavesTheState()
+        {
+            // Arrange
+            var store = new OriginalBrightnessStore(_stateService.Object);
+
+            // Act
+            store.RecordOriginal(HardwareId, 80);
+
+            // Assert
+            Assert.True(store.TryGetOriginal(HardwareId, out var brightness));
+            Assert.Equal(80u, brightness);
+            _stateService.Verify(s => s.SaveState(It.Is<Dictionary<string, uint>>(d => d[HardwareId] == 80)), Times.Once);
+        }
+
+        [Fact]
+        public void RecordOriginal_WhenMonitorAlreadyHasARecording_KeepsTheFirstAndDoesNotSaveAgain()
+        {
+            // Arrange
+            var store = new OriginalBrightnessStore(_stateService.Object);
+            store.RecordOriginal(HardwareId, 80);
+
+            // Act
+            store.RecordOriginal(HardwareId, 5);
+
+            // Assert
+            Assert.True(store.TryGetOriginal(HardwareId, out var brightness));
+            Assert.Equal(80u, brightness);
+            _stateService.Verify(s => s.SaveState(It.IsAny<Dictionary<string, uint>>()), Times.Once);
+        }
+
+        [Fact]
+        public void RemoveOriginal_WhenMonitorHasARecording_RemovesItAndSavesTheState()
+        {
+            // Arrange
+            var store = new OriginalBrightnessStore(_stateService.Object);
+            store.RecordOriginal(HardwareId, 80);
+
+            // Act
+            store.RemoveOriginal(HardwareId);
+
+            // Assert
+            Assert.False(store.TryGetOriginal(HardwareId, out _));
+            _stateService.Verify(s => s.SaveState(It.Is<Dictionary<string, uint>>(d => d.Count == 0)), Times.Once);
+        }
+
+        [Fact]
+        public void RemoveOriginal_WhenMonitorHasNoRecording_DoesNotSave()
+        {
+            // Arrange
+            var store = new OriginalBrightnessStore(_stateService.Object);
+
+            // Act
+            store.RemoveOriginal(HardwareId);
+
+            // Assert
+            _stateService.Verify(s => s.SaveState(It.IsAny<Dictionary<string, uint>>()), Times.Never);
+        }
+
+        [Fact]
+        public void GetAll_WhenTheResultIsMutated_LeavesTheStoreUnchanged()
+        {
+            // Arrange
+            var store = new OriginalBrightnessStore(_stateService.Object);
+            store.RecordOriginal(HardwareId, 80);
+
+            // Act
+            store.GetAll().Clear();
+
+            // Assert
+            Assert.True(store.TryGetOriginal(HardwareId, out _));
+        }
+    }
+}

--- a/OLED-Sleeper.Tests/TestDoubles/FakeDdcCiAccess.cs
+++ b/OLED-Sleeper.Tests/TestDoubles/FakeDdcCiAccess.cs
@@ -1,0 +1,48 @@
+using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
+
+namespace OLED_Sleeper.Tests.TestDoubles
+{
+    /// <summary>
+    /// An <see cref="IDdcCiAccess"/> over a set of fake panels, keyed by device name. A device with no
+    /// panel behind it reports as unreachable. Each device keeps one session across every open, so its
+    /// brightness survives and its disposals can be counted.
+    /// </summary>
+    public class FakeDdcCiAccess : IDdcCiAccess
+    {
+        private readonly Dictionary<string, FakeDdcCiSession> _panels = new();
+
+        /// <summary>
+        /// Every device name <see cref="OpenSession"/> was called with, in order, including ones that
+        /// had no panel behind them.
+        /// </summary>
+        public List<string> OpenAttempts { get; } = new();
+
+        /// <summary>
+        /// Runs at the start of every <see cref="OpenSession"/> call, before the panel is looked up.
+        /// A test can block here to hold an operation open inside the monitor's gate.
+        /// </summary>
+        public Action<string>? OnOpen { get; set; }
+
+        /// <summary>
+        /// Adds a reachable panel for the given device name.
+        /// </summary>
+        /// <param name="deviceName">The display device name.</param>
+        /// <param name="brightness">The brightness the panel reports before anything is written.</param>
+        /// <returns>The panel, so a test can script its failures and read what was written to it.</returns>
+        public FakeDdcCiSession AddPanel(string deviceName, uint brightness)
+        {
+            var panel = new FakeDdcCiSession(brightness);
+            _panels[deviceName] = panel;
+            return panel;
+        }
+
+        /// <inheritdoc />
+        public IDdcCiSession? OpenSession(string deviceName)
+        {
+            OpenAttempts.Add(deviceName);
+            OnOpen?.Invoke(deviceName);
+
+            return _panels.TryGetValue(deviceName, out var panel) ? panel : null;
+        }
+    }
+}

--- a/OLED-Sleeper.Tests/TestDoubles/FakeDdcCiSession.cs
+++ b/OLED-Sleeper.Tests/TestDoubles/FakeDdcCiSession.cs
@@ -1,0 +1,69 @@
+using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
+
+namespace OLED_Sleeper.Tests.TestDoubles
+{
+    /// <summary>
+    /// An <see cref="IDdcCiSession"/> that stands in for a panel, holding a brightness value instead of
+    /// talking to hardware. A write is reflected by the next read, so a restore confirms by default.
+    /// </summary>
+    public class FakeDdcCiSession : IDdcCiSession
+    {
+        private uint _brightness;
+
+        /// <param name="brightness">The brightness the panel reports before anything is written.</param>
+        public FakeDdcCiSession(uint brightness)
+        {
+            _brightness = brightness;
+        }
+
+        /// <summary>
+        /// When true, <see cref="GetBrightness"/> reports that the monitor did not answer.
+        /// </summary>
+        public bool ReadsFail { get; set; }
+
+        /// <summary>
+        /// When true, <see cref="SetBrightness"/> records the attempt and reports that the monitor
+        /// rejected it, leaving the held brightness untouched.
+        /// </summary>
+        public bool WritesAreRejected { get; set; }
+
+        /// <summary>
+        /// The value the panel reports after a write, whatever was written. Null reflects the written
+        /// value back, which is what a monitor that applied it does.
+        /// </summary>
+        public uint? ReadBackOverride { get; set; }
+
+        /// <summary>
+        /// Every value passed to <see cref="SetBrightness"/>, in order, including rejected writes.
+        /// </summary>
+        public List<uint> WrittenBrightnessLevels { get; } = new();
+
+        /// <summary>
+        /// How many times <see cref="Dispose"/> has run. One per channel the service opened means
+        /// no handle was leaked.
+        /// </summary>
+        public int DisposeCount { get; private set; }
+
+        /// <inheritdoc />
+        public uint? GetBrightness()
+        {
+            return ReadsFail ? null : _brightness;
+        }
+
+        /// <inheritdoc />
+        public bool SetBrightness(uint brightness)
+        {
+            WrittenBrightnessLevels.Add(brightness);
+            if (WritesAreRejected) return false;
+
+            _brightness = ReadBackOverride ?? brightness;
+            return true;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            DisposeCount++;
+        }
+    }
+}

--- a/OLED-Sleeper/Features/MonitorDimming/Helpers/BrightnessScale.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Helpers/BrightnessScale.cs
@@ -1,0 +1,29 @@
+namespace OLED_Sleeper.Features.MonitorDimming.Helpers
+{
+    /// <summary>
+    /// Maps dim levels expressed as percentages onto a monitor's own brightness range.
+    /// This is a static helper class and does not hold any state.
+    /// </summary>
+    public static class BrightnessScale
+    {
+        /// <summary>Upper bound of the percentage scale that the settings and the UI express the dim level on.</summary>
+        private const uint DimLevelPercentageMax = 100;
+
+        /// <summary>
+        /// Maps a percentage onto a monitor's brightness range.
+        /// </summary>
+        /// <param name="dimLevelPercentage">The dim level as a percentage. Values outside 0-100 are clamped.</param>
+        /// <param name="maxBrightness">The monitor's highest accepted brightness value.</param>
+        /// <returns>
+        /// The percentage itself when the monitor reported no range or already runs on a 0-100 scale;
+        /// otherwise the percentage of <paramref name="maxBrightness"/>.
+        /// </returns>
+        public static uint ToRawBrightness(int dimLevelPercentage, uint maxBrightness)
+        {
+            var percentage = (uint)Math.Clamp(dimLevelPercentage, 0, (int)DimLevelPercentageMax);
+            if (maxBrightness == 0 || maxBrightness == DimLevelPercentageMax) return percentage;
+
+            return (uint)Math.Round(percentage * maxBrightness / (double)DimLevelPercentageMax, MidpointRounding.AwayFromZero);
+        }
+    }
+}

--- a/OLED-Sleeper/Features/MonitorDimming/Services/DdcCiAccess.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/DdcCiAccess.cs
@@ -1,5 +1,6 @@
 using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
 using OLED_Sleeper.Native;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace OLED_Sleeper.Features.MonitorDimming.Services
@@ -8,6 +9,7 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
     /// Opens DDC/CI channels by matching a display device name against the enumerated monitors.
     /// Holds every native call the dimming feature makes.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class DdcCiAccess : IDdcCiAccess
     {
         /// <inheritdoc />

--- a/OLED-Sleeper/Features/MonitorDimming/Services/DdcCiAccess.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/DdcCiAccess.cs
@@ -1,0 +1,48 @@
+using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
+using OLED_Sleeper.Native;
+using System.Runtime.InteropServices;
+
+namespace OLED_Sleeper.Features.MonitorDimming.Services
+{
+    /// <summary>
+    /// Opens DDC/CI channels by matching a display device name against the enumerated monitors.
+    /// Holds every native call the dimming feature makes.
+    /// </summary>
+    public class DdcCiAccess : IDdcCiAccess
+    {
+        /// <inheritdoc />
+        public IDdcCiSession? OpenSession(string deviceName)
+        {
+            var hMonitor = FindMonitorHandle(deviceName);
+            if (hMonitor == nint.Zero) return null;
+
+            var physicalMonitors = new NativeMethods.PHYSICAL_MONITOR[1];
+            if (!NativeMethods.GetPhysicalMonitorsFromHMONITOR(hMonitor, 1, physicalMonitors)) return null;
+
+            return new DdcCiSession(physicalMonitors);
+        }
+
+        /// <summary>
+        /// Finds the monitor handle (HMONITOR) for the given device name.
+        /// </summary>
+        /// <param name="deviceName">The display device name to match.</param>
+        /// <returns>The HMONITOR handle, or zero when no monitor matched.</returns>
+        private static nint FindMonitorHandle(string deviceName)
+        {
+            nint foundMonitor = nint.Zero;
+            NativeMethods.MonitorEnumProc callback = (IntPtr hMonitor, IntPtr hdcMonitor, ref NativeMethods.Rect lprcMonitor, IntPtr dwData) =>
+            {
+                var mi = new NativeMethods.MonitorInfoEx { cbSize = Marshal.SizeOf(typeof(NativeMethods.MonitorInfoEx)) };
+                if (NativeMethods.GetMonitorInfo(hMonitor, ref mi) && mi.szDevice == deviceName)
+                {
+                    foundMonitor = hMonitor;
+                    return false; // Stop enumerating once we've found it
+                }
+                return true; // Continue enumerating
+            };
+
+            NativeMethods.EnumDisplayMonitors(nint.Zero, nint.Zero, callback, nint.Zero);
+            return foundMonitor;
+        }
+    }
+}

--- a/OLED-Sleeper/Features/MonitorDimming/Services/DdcCiSession.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/DdcCiSession.cs
@@ -1,11 +1,13 @@
 using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
 using OLED_Sleeper.Native;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OLED_Sleeper.Features.MonitorDimming.Services
 {
     /// <summary>
     /// A DDC/CI channel backed by a physical monitor handle from dxva2.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     internal sealed class DdcCiSession : IDdcCiSession
     {
         private readonly NativeMethods.PHYSICAL_MONITOR[] _physicalMonitors;

--- a/OLED-Sleeper/Features/MonitorDimming/Services/DdcCiSession.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/DdcCiSession.cs
@@ -1,0 +1,50 @@
+using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
+using OLED_Sleeper.Native;
+
+namespace OLED_Sleeper.Features.MonitorDimming.Services
+{
+    /// <summary>
+    /// A DDC/CI channel backed by a physical monitor handle from dxva2.
+    /// </summary>
+    internal sealed class DdcCiSession : IDdcCiSession
+    {
+        private readonly NativeMethods.PHYSICAL_MONITOR[] _physicalMonitors;
+        private readonly nint _hPhysicalMonitor;
+        private bool _disposed;
+
+        internal DdcCiSession(NativeMethods.PHYSICAL_MONITOR[] physicalMonitors)
+        {
+            _physicalMonitors = physicalMonitors;
+            _hPhysicalMonitor = physicalMonitors[0].hPhysicalMonitor;
+        }
+
+        /// <inheritdoc />
+        public uint? GetBrightness()
+        {
+            if (!NativeMethods.GetVCPFeatureAndVCPFeatureReply(
+                    _hPhysicalMonitor, NativeMethods.VCP_CODE_BRIGHTNESS, nint.Zero, out var currentBrightness, out _))
+            {
+                return null;
+            }
+
+            return currentBrightness;
+        }
+
+        /// <inheritdoc />
+        public bool SetBrightness(uint brightness)
+        {
+            return NativeMethods.SetVCPFeature(_hPhysicalMonitor, NativeMethods.VCP_CODE_BRIGHTNESS, brightness);
+        }
+
+        /// <summary>
+        /// Releases the physical monitor handle. Calls after the first do nothing.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed) return;
+
+            _disposed = true;
+            NativeMethods.DestroyPhysicalMonitors(1, _physicalMonitors);
+        }
+    }
+}

--- a/OLED-Sleeper/Features/MonitorDimming/Services/Interfaces/IDdcCiAccess.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/Interfaces/IDdcCiAccess.cs
@@ -1,0 +1,15 @@
+namespace OLED_Sleeper.Features.MonitorDimming.Services.Interfaces
+{
+    /// <summary>
+    /// Opens DDC/CI channels to attached monitors.
+    /// </summary>
+    public interface IDdcCiAccess
+    {
+        /// <summary>
+        /// Opens a channel to the monitor with the given device name.
+        /// </summary>
+        /// <param name="deviceName">The display device name, such as <c>\\.\DISPLAY1</c>.</param>
+        /// <returns>The channel, or null when the monitor could not be reached. The caller disposes it.</returns>
+        IDdcCiSession? OpenSession(string deviceName);
+    }
+}

--- a/OLED-Sleeper/Features/MonitorDimming/Services/Interfaces/IDdcCiSession.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/Interfaces/IDdcCiSession.cs
@@ -1,0 +1,22 @@
+namespace OLED_Sleeper.Features.MonitorDimming.Services.Interfaces
+{
+    /// <summary>
+    /// An open DDC/CI channel to one monitor. Reads and writes issued through it share a
+    /// single physical monitor handle, which is released on disposal.
+    /// </summary>
+    public interface IDdcCiSession : IDisposable
+    {
+        /// <summary>
+        /// Reads the monitor's current brightness.
+        /// </summary>
+        /// <returns>The raw brightness value, or null when the monitor did not answer.</returns>
+        uint? GetBrightness();
+
+        /// <summary>
+        /// Writes a brightness value to the monitor.
+        /// </summary>
+        /// <param name="brightness">The raw value, on the monitor's own scale rather than a percentage.</param>
+        /// <returns>True when the monitor accepted the write; otherwise, false.</returns>
+        bool SetBrightness(uint brightness);
+    }
+}

--- a/OLED-Sleeper/Features/MonitorDimming/Services/Interfaces/IOriginalBrightnessStore.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/Interfaces/IOriginalBrightnessStore.cs
@@ -1,0 +1,36 @@
+namespace OLED_Sleeper.Features.MonitorDimming.Services.Interfaces
+{
+    /// <summary>
+    /// Holds each dimmed monitor's pre-dim brightness and keeps the state file in step with it.
+    /// </summary>
+    public interface IOriginalBrightnessStore
+    {
+        /// <summary>
+        /// Gets the recorded pre-dim brightness for a monitor.
+        /// </summary>
+        /// <param name="hardwareId">The unique hardware ID of the monitor.</param>
+        /// <param name="brightness">The recorded raw brightness value, or zero when there is no recording.</param>
+        /// <returns>True when the monitor has a recording; otherwise, false.</returns>
+        bool TryGetOriginal(string hardwareId, out uint brightness);
+
+        /// <summary>
+        /// Records the pre-dim brightness for a monitor and saves the state.
+        /// An existing entry is kept, not overwritten.
+        /// </summary>
+        /// <param name="hardwareId">The unique hardware ID of the monitor.</param>
+        /// <param name="brightness">The raw brightness value to record.</param>
+        void RecordOriginal(string hardwareId, uint brightness);
+
+        /// <summary>
+        /// Removes a monitor's recording and saves the state. Does nothing when there is no recording.
+        /// </summary>
+        /// <param name="hardwareId">The unique hardware ID of the monitor.</param>
+        void RemoveOriginal(string hardwareId);
+
+        /// <summary>
+        /// Gets every recording.
+        /// </summary>
+        /// <returns>A copy of the map from hardware ID to raw pre-dim brightness.</returns>
+        Dictionary<string, uint> GetAll();
+    }
+}

--- a/OLED-Sleeper/Features/MonitorDimming/Services/MonitorDimmingService.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/MonitorDimmingService.cs
@@ -1,10 +1,8 @@
+using OLED_Sleeper.Features.MonitorDimming.Helpers;
 using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
-using OLED_Sleeper.Features.MonitorInformation.Models;
 using OLED_Sleeper.Features.MonitorInformation.Services.Interfaces;
-using OLED_Sleeper.Native;
 using Serilog;
 using System.Collections.Concurrent;
-using System.Runtime.InteropServices;
 
 namespace OLED_Sleeper.Features.MonitorDimming.Services
 {
@@ -15,7 +13,8 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
     public class MonitorDimmingService : IMonitorDimmingService
     {
         private readonly IMonitorInfoManager _monitorManager;
-        private readonly IMonitorBrightnessStateService _brightnessStateService;
+        private readonly IDdcCiAccess _ddcCiAccess;
+        private readonly IOriginalBrightnessStore _originalBrightnessStore;
 
         /// <summary>Number of times a restore write is attempted before the recording is kept and the attempt abandoned.</summary>
         private const int RestoreAttempts = 3;
@@ -26,30 +25,19 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
         /// <summary>Largest difference between the requested and read-back brightness that still counts as applied.</summary>
         private const uint BrightnessReadBackTolerance = 2;
 
-        /// <summary>Returned by <see cref="GetCurrentBrightness"/> when the monitor could not be read.</summary>
-        private const uint BrightnessUnknown = uint.MaxValue;
-
-        /// <summary>Upper bound of the percentage scale that the settings and the UI express the dim level on.</summary>
-        private const uint DimLevelPercentageMax = 100;
-
-        /// <summary>Guards <see cref="_originalBrightnessLevels"/> and the state file write that follows each change to it.</summary>
-        private readonly object _stateLock = new();
-
-        private readonly Dictionary<string, uint> _originalBrightnessLevels;
-
         /// <summary>
         /// One gate per hardware ID. Dim, undim and restore for the same monitor run one at a time.
         /// </summary>
         private readonly ConcurrentDictionary<string, SemaphoreSlim> _monitorGates = new();
 
-        /// <summary>
-        /// Loads the recorded original brightness levels from disk.
-        /// </summary>
-        public MonitorDimmingService(IMonitorInfoManager monitorManager, IMonitorBrightnessStateService brightnessStateService)
+        public MonitorDimmingService(
+            IMonitorInfoManager monitorManager,
+            IDdcCiAccess ddcCiAccess,
+            IOriginalBrightnessStore originalBrightnessStore)
         {
             _monitorManager = monitorManager;
-            _brightnessStateService = brightnessStateService;
-            _originalBrightnessLevels = _brightnessStateService.LoadState();
+            _ddcCiAccess = ddcCiAccess;
+            _originalBrightnessStore = originalBrightnessStore;
         }
 
         /// <inheritdoc />
@@ -79,10 +67,7 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
         /// <inheritdoc />
         public Dictionary<string, uint> GetDimmedMonitors()
         {
-            lock (_stateLock)
-            {
-                return new Dictionary<string, uint>(_originalBrightnessLevels);
-            }
+            return _originalBrightnessStore.GetAll();
         }
 
         #region Private Helpers
@@ -112,13 +97,13 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
         {
             var targetBrightness = await ScaleToMonitorRangeAsync(hardwareId, dimLevel);
 
-            await WithPhysicalMonitorAsync(hardwareId, hPhysicalMonitor =>
+            await WithSessionAsync(hardwareId, session =>
             {
-                var currentBrightness = GetCurrentBrightness(hPhysicalMonitor, hardwareId);
-                if (currentBrightness == BrightnessUnknown) return false;
+                var currentBrightness = GetCurrentBrightness(session, hardwareId);
+                if (currentBrightness is null) return false;
 
-                RecordOriginalBrightness(hardwareId, currentBrightness);
-                return SetMonitorBrightness(hPhysicalMonitor, hardwareId, targetBrightness);
+                _originalBrightnessStore.RecordOriginal(hardwareId, currentBrightness.Value);
+                return SetMonitorBrightness(session, hardwareId, targetBrightness);
             });
         }
 
@@ -134,7 +119,7 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
             var monitors = await _monitorManager.GetCurrentMonitorsAsync();
             var maxBrightness = monitors.FirstOrDefault(m => m.HardwareId == hardwareId)?.MaxBrightness ?? 0;
 
-            var targetBrightness = ScaleToRange(dimLevel, maxBrightness);
+            var targetBrightness = BrightnessScale.ToRawBrightness(dimLevel, maxBrightness);
             if (targetBrightness != dimLevel)
             {
                 Log.Debug("Dim level {DimLevel}% scales to brightness {TargetBrightness} on monitor {HardwareId}, whose range is 0-{MaxBrightness}.",
@@ -145,23 +130,6 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
         }
 
         /// <summary>
-        /// Maps a percentage onto a monitor's brightness range.
-        /// </summary>
-        /// <param name="dimLevelPercentage">The dim level as a percentage. Values outside 0-100 are clamped.</param>
-        /// <param name="maxBrightness">The monitor's highest accepted brightness value.</param>
-        /// <returns>
-        /// The percentage itself when the monitor reported no range or already runs on a 0-100 scale;
-        /// otherwise the percentage of <paramref name="maxBrightness"/>.
-        /// </returns>
-        private static uint ScaleToRange(int dimLevelPercentage, uint maxBrightness)
-        {
-            var percentage = (uint)Math.Clamp(dimLevelPercentage, 0, (int)DimLevelPercentageMax);
-            if (maxBrightness == 0 || maxBrightness == DimLevelPercentageMax) return percentage;
-
-            return (uint)Math.Round(percentage * maxBrightness / (double)DimLevelPercentageMax, MidpointRounding.AwayFromZero);
-        }
-
-        /// <summary>
         /// Sets the monitor back to its recorded original brightness and drops the recording.
         /// Does nothing if there is no recording. The recording is kept when the restore could not be confirmed,
         /// so a later reconnect, settings save, or the next launch retries it.
@@ -169,15 +137,11 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
         /// <param name="hardwareId">The hardware ID of the monitor.</param>
         private async Task UndimCoreAsync(string hardwareId)
         {
-            uint originalBrightness;
-            lock (_stateLock)
-            {
-                if (!_originalBrightnessLevels.TryGetValue(hardwareId, out originalBrightness)) return;
-            }
+            if (!_originalBrightnessStore.TryGetOriginal(hardwareId, out var originalBrightness)) return;
 
             if (await RestoreCoreAsync(hardwareId, originalBrightness))
             {
-                RemoveOriginalBrightness(hardwareId);
+                _originalBrightnessStore.RemoveOriginal(hardwareId);
             }
         }
 
@@ -192,9 +156,9 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
         {
             for (var attempt = 1; attempt <= RestoreAttempts; attempt++)
             {
-                var outcome = await WithPhysicalMonitorAsync(hardwareId, hPhysicalMonitor =>
-                    SetMonitorBrightness(hPhysicalMonitor, hardwareId, originalBrightness, isRestore: true)
-                    && BrightnessWasApplied(hPhysicalMonitor, hardwareId, originalBrightness));
+                var outcome = await WithSessionAsync(hardwareId, session =>
+                    SetMonitorBrightness(session, hardwareId, originalBrightness, isRestore: true)
+                    && BrightnessWasApplied(session, hardwareId, originalBrightness));
 
                 if (outcome == MonitorAccessOutcome.Succeeded)
                 {
@@ -223,23 +187,23 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
         /// <summary>
         /// Reads the monitor's brightness back and compares it against the value that was written.
         /// </summary>
-        /// <param name="hPhysicalMonitor">The physical monitor handle.</param>
+        /// <param name="session">The open channel to the monitor.</param>
         /// <param name="hardwareId">The hardware ID of the monitor.</param>
         /// <param name="expectedBrightness">The brightness value that was written.</param>
         /// <returns>True when the read-back is within <see cref="BrightnessReadBackTolerance"/> of the written value.</returns>
-        private bool BrightnessWasApplied(nint hPhysicalMonitor, string hardwareId, uint expectedBrightness)
+        private static bool BrightnessWasApplied(IDdcCiSession session, string hardwareId, uint expectedBrightness)
         {
-            var actualBrightness = GetCurrentBrightness(hPhysicalMonitor, hardwareId);
-            if (actualBrightness == BrightnessUnknown) return false;
+            var actualBrightness = GetCurrentBrightness(session, hardwareId);
+            if (actualBrightness is null) return false;
 
-            var difference = actualBrightness > expectedBrightness
-                ? actualBrightness - expectedBrightness
-                : expectedBrightness - actualBrightness;
+            var difference = actualBrightness.Value > expectedBrightness
+                ? actualBrightness.Value - expectedBrightness
+                : expectedBrightness - actualBrightness.Value;
 
             if (difference <= BrightnessReadBackTolerance) return true;
 
             Log.Warning("Monitor {HardwareId} reports brightness {ActualBrightness} after being set to {ExpectedBrightness}.",
-                hardwareId, actualBrightness, expectedBrightness);
+                hardwareId, actualBrightness.Value, expectedBrightness);
             return false;
         }
 
@@ -263,126 +227,55 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
         }
 
         /// <summary>
-        /// Safely obtains and destroys a physical monitor handle, executing the provided operation.
+        /// Opens a DDC/CI channel to the monitor for the duration of the operation and closes it afterwards.
+        /// This is the only place a channel is opened.
         /// </summary>
         /// <param name="hardwareId">The hardware ID of the monitor.</param>
-        /// <param name="operation">The operation to perform with the monitor handle. Returns whether it succeeded.</param>
-        /// <returns><see cref="MonitorAccessOutcome.Unavailable"/> when the handle could not be obtained and the operation never ran.</returns>
-        private async Task<MonitorAccessOutcome> WithPhysicalMonitorAsync(string hardwareId, Func<nint, bool> operation)
+        /// <param name="operation">The operation to perform on the channel. Returns whether it succeeded.</param>
+        /// <returns><see cref="MonitorAccessOutcome.Unavailable"/> when the monitor could not be reached and the operation never ran.</returns>
+        private async Task<MonitorAccessOutcome> WithSessionAsync(string hardwareId, Func<IDdcCiSession, bool> operation)
         {
-            var hMonitor = await FindMonitorHandleByHardwareIdAsync(hardwareId);
-            if (hMonitor == nint.Zero)
+            var monitors = await _monitorManager.GetCurrentMonitorsAsync();
+            var targetMonitor = monitors.FirstOrDefault(m => m.HardwareId == hardwareId);
+
+            using var session = targetMonitor is null ? null : _ddcCiAccess.OpenSession(targetMonitor.DeviceName);
+            if (session is null)
             {
                 Log.Warning("Could not find monitor handle for HardwareId {HardwareId}.", hardwareId);
                 return MonitorAccessOutcome.Unavailable;
             }
 
-            var physicalMonitors = new NativeMethods.PHYSICAL_MONITOR[1];
-            if (!NativeMethods.GetPhysicalMonitorsFromHMONITOR(hMonitor, 1, physicalMonitors))
-            {
-                Log.Warning("Could not get physical monitor from HMONITOR for HardwareId {HardwareId}.", hardwareId);
-                return MonitorAccessOutcome.Unavailable;
-            }
-
-            var hPhysicalMonitor = physicalMonitors[0].hPhysicalMonitor;
-            try
-            {
-                return operation(hPhysicalMonitor) ? MonitorAccessOutcome.Succeeded : MonitorAccessOutcome.Failed;
-            }
-            finally
-            {
-                NativeMethods.DestroyPhysicalMonitors(1, physicalMonitors);
-            }
-        }
-
-        /// <summary>
-        /// Finds the monitor handle (HMONITOR) for the given hardware ID.
-        /// </summary>
-        /// <param name="hardwareId">The hardware ID of the monitor.</param>
-        /// <returns>The HMONITOR handle, or IntPtr.Zero if not found.</returns>
-        private async Task<nint> FindMonitorHandleByHardwareIdAsync(string hardwareId)
-        {
-            var allMonitors = await _monitorManager.GetCurrentMonitorsAsync();
-            var targetMonitor = allMonitors.FirstOrDefault(m => m.HardwareId == hardwareId);
-            if (targetMonitor == null) return nint.Zero;
-
-            nint foundMonitor = nint.Zero;
-            NativeMethods.MonitorEnumProc callback = (IntPtr hMonitor, IntPtr hdcMonitor, ref NativeMethods.Rect lprcMonitor, IntPtr dwData) =>
-            {
-                var mi = new NativeMethods.MonitorInfoEx { cbSize = Marshal.SizeOf(typeof(NativeMethods.MonitorInfoEx)) };
-                if (NativeMethods.GetMonitorInfo(hMonitor, ref mi) && mi.szDevice == targetMonitor.DeviceName)
-                {
-                    foundMonitor = hMonitor;
-                    return false; // Stop enumerating once we've found it
-                }
-                return true; // Continue enumerating
-            };
-
-            NativeMethods.EnumDisplayMonitors(nint.Zero, nint.Zero, callback, nint.Zero);
-            return foundMonitor;
+            return operation(session) ? MonitorAccessOutcome.Succeeded : MonitorAccessOutcome.Failed;
         }
 
         /// <summary>
         /// Gets the current brightness of the monitor.
         /// </summary>
-        /// <param name="hPhysicalMonitor">The physical monitor handle.</param>
+        /// <param name="session">The open channel to the monitor.</param>
         /// <param name="hardwareId">The hardware ID of the monitor.</param>
-        /// <returns>The current brightness, or <see cref="BrightnessUnknown"/> if the read failed.</returns>
-        private uint GetCurrentBrightness(nint hPhysicalMonitor, string hardwareId)
+        /// <returns>The current brightness, or null if the read failed.</returns>
+        private static uint? GetCurrentBrightness(IDdcCiSession session, string hardwareId)
         {
-            if (NativeMethods.GetVCPFeatureAndVCPFeatureReply(hPhysicalMonitor, NativeMethods.VCP_CODE_BRIGHTNESS, nint.Zero, out var currentBrightness, out _))
+            var currentBrightness = session.GetBrightness();
+            if (currentBrightness is null)
             {
-                return currentBrightness;
+                Log.Warning("Failed to get current brightness for monitor {HardwareId}.", hardwareId);
             }
-            Log.Warning("Failed to get current brightness for monitor {HardwareId}.", hardwareId);
-            return BrightnessUnknown;
-        }
 
-        /// <summary>
-        /// Records the original brightness for the monitor and saves the state.
-        /// An existing entry is kept, not overwritten.
-        /// </summary>
-        /// <param name="hardwareId">The hardware ID of the monitor.</param>
-        /// <param name="brightness">The brightness value to record.</param>
-        private void RecordOriginalBrightness(string hardwareId, uint brightness)
-        {
-            lock (_stateLock)
-            {
-                if (_originalBrightnessLevels.ContainsKey(hardwareId))
-                {
-                    Log.Debug("Monitor {HardwareId} already has a recorded original brightness of {Brightness}.", hardwareId, _originalBrightnessLevels[hardwareId]);
-                    return;
-                }
-
-                _originalBrightnessLevels[hardwareId] = brightness;
-                _brightnessStateService.SaveState(new Dictionary<string, uint>(_originalBrightnessLevels));
-            }
-        }
-
-        /// <summary>
-        /// Removes the original brightness entry for the monitor and saves the state.
-        /// </summary>
-        /// <param name="hardwareId">The hardware ID of the monitor.</param>
-        private void RemoveOriginalBrightness(string hardwareId)
-        {
-            lock (_stateLock)
-            {
-                if (!_originalBrightnessLevels.Remove(hardwareId)) return;
-                _brightnessStateService.SaveState(new Dictionary<string, uint>(_originalBrightnessLevels));
-            }
+            return currentBrightness;
         }
 
         /// <summary>
         /// Sets the brightness of the monitor and logs the operation.
         /// </summary>
-        /// <param name="hPhysicalMonitor">The physical monitor handle.</param>
+        /// <param name="session">The open channel to the monitor.</param>
         /// <param name="hardwareId">The hardware ID of the monitor.</param>
         /// <param name="brightness">The brightness value to set.</param>
         /// <param name="isRestore">True if restoring, false if dimming.</param>
         /// <returns>True when the monitor accepted the write; otherwise, false.</returns>
-        private bool SetMonitorBrightness(nint hPhysicalMonitor, string hardwareId, uint brightness, bool isRestore = false)
+        private static bool SetMonitorBrightness(IDdcCiSession session, string hardwareId, uint brightness, bool isRestore = false)
         {
-            if (!NativeMethods.SetVCPFeature(hPhysicalMonitor, NativeMethods.VCP_CODE_BRIGHTNESS, brightness))
+            if (!session.SetBrightness(brightness))
             {
                 var action = isRestore ? "restore brightness on" : "dim";
                 Log.Warning("Failed to {Action} monitor {HardwareId}.", action, hardwareId);

--- a/OLED-Sleeper/Features/MonitorDimming/Services/OriginalBrightnessStore.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/OriginalBrightnessStore.cs
@@ -1,0 +1,73 @@
+using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
+using Serilog;
+
+namespace OLED_Sleeper.Features.MonitorDimming.Services
+{
+    /// <summary>
+    /// Keeps each dimmed monitor's pre-dim brightness in memory and mirrors every change to the state file.
+    /// Every member is safe to call from any thread.
+    /// </summary>
+    public class OriginalBrightnessStore : IOriginalBrightnessStore
+    {
+        private readonly IMonitorBrightnessStateService _brightnessStateService;
+
+        /// <summary>Guards <see cref="_originalBrightnessLevels"/> and the state file write that follows each change to it.</summary>
+        private readonly object _stateLock = new();
+
+        private readonly Dictionary<string, uint> _originalBrightnessLevels;
+
+        /// <summary>
+        /// Loads the recorded original brightness levels from disk.
+        /// </summary>
+        public OriginalBrightnessStore(IMonitorBrightnessStateService brightnessStateService)
+        {
+            _brightnessStateService = brightnessStateService;
+            _originalBrightnessLevels = _brightnessStateService.LoadState();
+        }
+
+        /// <inheritdoc />
+        public bool TryGetOriginal(string hardwareId, out uint brightness)
+        {
+            lock (_stateLock)
+            {
+                return _originalBrightnessLevels.TryGetValue(hardwareId, out brightness);
+            }
+        }
+
+        /// <inheritdoc />
+        public void RecordOriginal(string hardwareId, uint brightness)
+        {
+            lock (_stateLock)
+            {
+                if (_originalBrightnessLevels.TryGetValue(hardwareId, out var recorded))
+                {
+                    Log.Debug("Monitor {HardwareId} already has a recorded original brightness of {Brightness}.", hardwareId, recorded);
+                    return;
+                }
+
+                _originalBrightnessLevels[hardwareId] = brightness;
+                _brightnessStateService.SaveState(new Dictionary<string, uint>(_originalBrightnessLevels));
+            }
+        }
+
+        /// <inheritdoc />
+        public void RemoveOriginal(string hardwareId)
+        {
+            lock (_stateLock)
+            {
+                if (!_originalBrightnessLevels.Remove(hardwareId)) return;
+
+                _brightnessStateService.SaveState(new Dictionary<string, uint>(_originalBrightnessLevels));
+            }
+        }
+
+        /// <inheritdoc />
+        public Dictionary<string, uint> GetAll()
+        {
+            lock (_stateLock)
+            {
+                return new Dictionary<string, uint>(_originalBrightnessLevels);
+            }
+        }
+    }
+}

--- a/OLED-Sleeper/Infrastructure/ServiceConfigurator.cs
+++ b/OLED-Sleeper/Infrastructure/ServiceConfigurator.cs
@@ -60,6 +60,8 @@ namespace OLED_Sleeper.Infrastructure
             services.AddSingleton<IMonitorInfoManager, MonitorInfoManager>();
             services.AddSingleton<IMonitorStateWatcher, MonitorStateWatcher>();
             services.AddSingleton<IMonitorBrightnessStateService, MonitorBrightnessStateService>();
+            services.AddSingleton<IOriginalBrightnessStore, OriginalBrightnessStore>();
+            services.AddSingleton<IDdcCiAccess, DdcCiAccess>();
             services.AddSingleton<IMonitorDimmingService, MonitorDimmingService>();
             services.AddSingleton<IOverlayWindowFactory, OverlayWindowFactory>();
             services.AddSingleton<IMonitorBlackoutService, MonitorBlackoutService>();


### PR DESCRIPTION
`MonitorDimmingService` splits into a native access seam, a durable brightness store and a pure scaling function, and gains tests.

* Not verified against real hardware. The unplug-then-exit path, where the recording is kept and no retry delay is spent on an unreachable monitor, is the one worth exercising by hand.
* One log message is merged: `Could not get physical monitor from HMONITOR for HardwareId` is gone, and both failures now log `Could not find monitor handle for HardwareId`. The `diagnose-dark-monitor` triage matches on that string.
* `RestoreBrightnessOnAllMonitorsCommandHandler` propagates exceptions where its two siblings swallow them, contradicting the handler contract in `app-lifecycle.md`. Pinned in a test here rather than changed.
* `DdcCiAccess` and `DdcCiSession` carry `[ExcludeFromCodeCoverage]`, which hides a real decision in `DdcCiAccess.FindMonitorHandle`. It sits inside the `EnumDisplayMonitors` callback, so the usual interface remedy does not apply.
* `MonitorBrightnessStateService` is still uncovered. Its `.tmp` / `File.Replace` / `.bak` write needs real temp-file I/O in the suite.
* `IMonitorDimmingService` is unchanged, so no caller moved.
