### PR TITLE
refactor: share one atomic json store between settings and brightness state

### DIFF
--- a/OLED-Sleeper/Features/MonitorDimming/Services/Interfaces/IMonitorBrightnessStateService.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/Interfaces/IMonitorBrightnessStateService.cs
@@ -8,7 +8,9 @@
         /// <summary>
         /// Loads the brightness state for all monitors from persistent storage.
         /// </summary>
-        /// <returns>A dictionary mapping monitor hardware IDs to their brightness values.</returns>
+        /// <returns>
+        /// A dictionary mapping monitor hardware IDs to their brightness values, empty when no state could be read.
+        /// </returns>
         Dictionary<string, uint> LoadState();
 
         /// <summary>

--- a/OLED-Sleeper/Features/MonitorDimming/Services/MonitorBrightnessStateService.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/MonitorBrightnessStateService.cs
@@ -1,115 +1,28 @@
-﻿using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
-using Serilog;
-using System.IO;
-using System.Text.Json;
+using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
+using OLED_Sleeper.Storage.Interfaces;
 
 namespace OLED_Sleeper.Features.MonitorDimming.Services
 {
     /// <summary>
-    /// Service for loading and saving the brightness state of monitors to disk.
+    /// Keeps the brightness state in <c>brightness_state.json</c> under the application's data directory.
     /// </summary>
     public class MonitorBrightnessStateService : IMonitorBrightnessStateService
     {
-        private readonly string _stateFilePath;
-        private readonly string _tempFilePath;
-        private readonly string _backupFilePath;
+        /// <summary>The name of the file the state is kept in.</summary>
+        private const string StateFileName = "brightness_state.json";
 
-        /// <summary>
-        /// Sets up the file path for storing brightness state in the user's AppData directory.
-        /// </summary>
-        public MonitorBrightnessStateService()
+        private readonly IAppDataFileStore _fileStore;
+
+        public MonitorBrightnessStateService(IAppDataFileStore fileStore)
         {
-            var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            var settingsDir = Path.Combine(appDataPath, "OLED-Sleeper");
-            Directory.CreateDirectory(settingsDir);
-            _stateFilePath = Path.Combine(settingsDir, "brightness_state.json");
-            _tempFilePath = _stateFilePath + ".tmp";
-            _backupFilePath = _stateFilePath + ".bak";
+            _fileStore = fileStore;
         }
 
-        #region IMonitorBrightnessStateService Implementation
-
-        /// <summary>
-        /// Loads the brightness state for all monitors from persistent storage.
-        /// Falls back to the backup file when the state file is missing or unreadable.
-        /// </summary>
-        /// <returns>A dictionary mapping monitor hardware IDs to their brightness values.</returns>
+        /// <inheritdoc />
         public Dictionary<string, uint> LoadState()
-        {
-            if (TryLoadFrom(_stateFilePath, out var state))
-            {
-                return state;
-            }
+            => _fileStore.Read<Dictionary<string, uint>>(StateFileName) ?? new Dictionary<string, uint>();
 
-            if (TryLoadFrom(_backupFilePath, out var backupState))
-            {
-                Log.Warning("Loaded brightness state from the backup file {FilePath}.", _backupFilePath);
-                return backupState;
-            }
-
-            return new Dictionary<string, uint>();
-        }
-
-        /// <summary>
-        /// Saves the brightness state for all monitors to persistent storage.
-        /// Writes to a temporary file and replaces the state file with it, keeping the previous contents as a backup.
-        /// </summary>
-        /// <param name="state">A dictionary mapping monitor hardware IDs to their brightness values.</param>
-        public void SaveState(Dictionary<string, uint> state)
-        {
-            try
-            {
-                var options = new JsonSerializerOptions { WriteIndented = true };
-                var json = JsonSerializer.Serialize(state, options);
-                File.WriteAllText(_tempFilePath, json);
-
-                if (File.Exists(_stateFilePath))
-                {
-                    File.Replace(_tempFilePath, _stateFilePath, _backupFilePath, ignoreMetadataErrors: true);
-                }
-                else
-                {
-                    File.Move(_tempFilePath, _stateFilePath);
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to save brightness state to {FilePath}.", _stateFilePath);
-            }
-        }
-
-        #endregion IMonitorBrightnessStateService Implementation
-
-        #region Private Methods
-
-        /// <summary>
-        /// Reads and deserializes a brightness state file.
-        /// </summary>
-        /// <param name="filePath">The path of the file to read.</param>
-        /// <param name="state">The deserialized state, or an empty dictionary when the file could not be read.</param>
-        /// <returns><c>true</c> if the file was read and deserialized; otherwise, <c>false</c>.</returns>
-        private static bool TryLoadFrom(string filePath, out Dictionary<string, uint> state)
-        {
-            state = new Dictionary<string, uint>();
-
-            if (!File.Exists(filePath))
-            {
-                return false;
-            }
-
-            try
-            {
-                var json = File.ReadAllText(filePath);
-                state = JsonSerializer.Deserialize<Dictionary<string, uint>>(json) ?? new Dictionary<string, uint>();
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to load brightness state from {FilePath}.", filePath);
-                return false;
-            }
-        }
-
-        #endregion Private Methods
+        /// <inheritdoc />
+        public void SaveState(Dictionary<string, uint> state) => _fileStore.TryWrite(StateFileName, state);
     }
 }

--- a/OLED-Sleeper/Features/UserSettings/Services/Interfaces/IMonitorSettingsFileService.cs
+++ b/OLED-Sleeper/Features/UserSettings/Services/Interfaces/IMonitorSettingsFileService.cs
@@ -22,7 +22,7 @@ namespace OLED_Sleeper.Features.UserSettings.Services.Interfaces
         /// <summary>
         /// Saves the provided monitor settings to persistent storage. Stored settings for monitors that are
         /// not in <paramref name="settings"/> are kept. <see cref="SettingsChanged"/> is raised only when the
-        /// save succeeded.
+        /// save succeeded. Never throws: a failed write and a subscriber that throws are both caught and logged.
         /// </summary>
         /// <param name="settings">The list of monitor settings to save.</param>
         void SaveSettings(List<MonitorSettings> settings);

--- a/OLED-Sleeper/Features/UserSettings/Services/Interfaces/IMonitorSettingsFileService.cs
+++ b/OLED-Sleeper/Features/UserSettings/Services/Interfaces/IMonitorSettingsFileService.cs
@@ -8,19 +8,21 @@ namespace OLED_Sleeper.Features.UserSettings.Services.Interfaces
     public interface IMonitorSettingsFileService
     {
         /// <summary>
-        /// Event raised when monitor settings are changed and saved.
+        /// Event raised after settings have been saved. It carries the settings the caller supplied rather than
+        /// the merged list that was written.
         /// </summary>
         event Action<List<MonitorSettings>>? SettingsChanged;
 
         /// <summary>
         /// Loads all monitor settings from persistent storage.
         /// </summary>
-        /// <returns>A list of <see cref="MonitorSettings"/> objects.</returns>
+        /// <returns>A list of <see cref="MonitorSettings"/> objects, empty when no settings could be read.</returns>
         List<MonitorSettings> LoadSettings();
 
         /// <summary>
         /// Saves the provided monitor settings to persistent storage. Stored settings for monitors that are
-        /// not in <paramref name="settings"/> are kept.
+        /// not in <paramref name="settings"/> are kept. <see cref="SettingsChanged"/> is raised only when the
+        /// save succeeded.
         /// </summary>
         /// <param name="settings">The list of monitor settings to save.</param>
         void SaveSettings(List<MonitorSettings> settings);

--- a/OLED-Sleeper/Features/UserSettings/Services/MonitorSettingsFileService.cs
+++ b/OLED-Sleeper/Features/UserSettings/Services/MonitorSettingsFileService.cs
@@ -34,12 +34,19 @@ namespace OLED_Sleeper.Features.UserSettings.Services
         /// <inheritdoc />
         public void SaveSettings(List<MonitorSettings> settings)
         {
-            var merged = MergeWithStoredSettings(settings);
+            try
+            {
+                var merged = MergeWithStoredSettings(settings);
 
-            if (!_fileStore.TryWrite(SettingsFileName, merged)) return;
+                if (!_fileStore.TryWrite(SettingsFileName, merged)) return;
 
-            Log.Information("Saved {Count} monitor settings.", merged.Count);
-            SettingsChanged?.Invoke(settings);
+                Log.Information("Saved {Count} monitor settings.", merged.Count);
+                SettingsChanged?.Invoke(settings);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to save monitor settings.");
+            }
         }
 
         /// <summary>

--- a/OLED-Sleeper/Features/UserSettings/Services/MonitorSettingsFileService.cs
+++ b/OLED-Sleeper/Features/UserSettings/Services/MonitorSettingsFileService.cs
@@ -1,89 +1,50 @@
-﻿using OLED_Sleeper.Features.UserSettings.Models;
+using OLED_Sleeper.Features.UserSettings.Models;
 using OLED_Sleeper.Features.UserSettings.Services.Interfaces;
+using OLED_Sleeper.Storage.Interfaces;
 using Serilog;
-using System.IO;
-using System.Text.Json;
 
 namespace OLED_Sleeper.Features.UserSettings.Services
 {
     /// <summary>
-    /// Service for loading and saving user settings to a JSON file in the user's AppData directory.
+    /// Keeps the monitor settings in <c>settings.json</c> under the application's data directory.
     /// </summary>
     public class MonitorSettingsFileService : IMonitorSettingsFileService
     {
-        // Fields
-        private readonly string _settingsFilePath;
+        /// <summary>The name of the file the settings are kept in.</summary>
+        private const string SettingsFileName = "settings.json";
 
-        /// <summary>
-        /// Occurs when monitor settings are changed and saved.
-        /// </summary>
+        private readonly IAppDataFileStore _fileStore;
+
+        /// <inheritdoc />
         public event Action<List<MonitorSettings>>? SettingsChanged;
 
-        /// <summary>
-        /// Ensures the settings directory exists and sets the file path.
-        /// </summary>
-        public MonitorSettingsFileService()
+        public MonitorSettingsFileService(IAppDataFileStore fileStore)
         {
-            var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            var settingsDir = Path.Combine(appDataPath, "OLED-Sleeper");
-            Directory.CreateDirectory(settingsDir);
-            _settingsFilePath = Path.Combine(settingsDir, "settings.json");
+            _fileStore = fileStore;
         }
 
-        /// <summary>
-        /// Loads monitor settings from the settings file.
-        /// Returns an empty list if the file does not exist or cannot be read.
-        /// </summary>
-        /// <returns>A list of <see cref="MonitorSettings"/> objects.</returns>
+        /// <inheritdoc />
         public List<MonitorSettings> LoadSettings()
         {
-            if (!File.Exists(_settingsFilePath))
-            {
-                Log.Information("Settings file not found. Returning default settings.");
-                return new List<MonitorSettings>();
-            }
-
-            try
-            {
-                var json = File.ReadAllText(_settingsFilePath);
-                var settings = JsonSerializer.Deserialize<List<MonitorSettings>>(json);
-                Log.Information("Successfully loaded {Count} monitor settings.", settings?.Count ?? 0);
-                return settings ?? new List<MonitorSettings>();
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to load settings from {FilePath}.", _settingsFilePath);
-                return new List<MonitorSettings>();
-            }
+            var settings = _fileStore.Read<List<MonitorSettings>>(SettingsFileName) ?? new List<MonitorSettings>();
+            Log.Information("Loaded {Count} monitor settings.", settings.Count);
+            return settings;
         }
 
-        /// <summary>
-        /// Saves the specified monitor settings to the settings file, keeping stored entries for monitors
-        /// the caller did not supply.
-        /// Invokes the <see cref="SettingsChanged"/> event with the supplied settings after a successful save.
-        /// </summary>
-        /// <param name="settings">The list of <see cref="MonitorSettings"/> to save.</param>
+        /// <inheritdoc />
         public void SaveSettings(List<MonitorSettings> settings)
         {
-            try
-            {
-                var merged = MergeWithStoredSettings(settings);
-                var options = new JsonSerializerOptions { WriteIndented = true };
-                var json = JsonSerializer.Serialize(merged, options);
-                File.WriteAllText(_settingsFilePath, json);
-                Log.Information("Successfully saved {Count} monitor settings to {FilePath}.", merged.Count, _settingsFilePath);
-                SettingsChanged?.Invoke(settings);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to save settings to {FilePath}.", _settingsFilePath);
-            }
+            var merged = MergeWithStoredSettings(settings);
+
+            if (!_fileStore.TryWrite(SettingsFileName, merged)) return;
+
+            Log.Information("Saved {Count} monitor settings.", merged.Count);
+            SettingsChanged?.Invoke(settings);
         }
 
         /// <summary>
         /// Appends the stored settings whose hardware ID is absent from <paramref name="settings"/> to the
-        /// supplied list. The caller only ever builds settings for connected monitors, so without this the
-        /// write would drop the configuration of every disconnected one.
+        /// supplied list, so the configuration of monitors that are not connected is kept.
         /// </summary>
         /// <param name="settings">The settings supplied by the caller.</param>
         /// <returns>The supplied settings followed by the stored settings that were kept.</returns>

--- a/OLED-Sleeper/Infrastructure/ServiceConfigurator.cs
+++ b/OLED-Sleeper/Infrastructure/ServiceConfigurator.cs
@@ -22,6 +22,8 @@ using OLED_Sleeper.Features.MonitorState.Services;
 using OLED_Sleeper.Features.MonitorState.Services.Interfaces;
 using OLED_Sleeper.Features.UserSettings.Services;
 using OLED_Sleeper.Features.UserSettings.Services.Interfaces;
+using OLED_Sleeper.Storage;
+using OLED_Sleeper.Storage.Interfaces;
 using OLED_Sleeper.UI.Services;
 using OLED_Sleeper.UI.Services.Interfaces;
 using OLED_Sleeper.UI.ViewModels;
@@ -57,6 +59,8 @@ namespace OLED_Sleeper.Infrastructure
 
             services.AddSingleton(Options.Create(applicationOptions));
 
+            services.AddSingleton<IFileSystem, FileSystem>();
+            services.AddSingleton<IAppDataFileStore, AppDataFileStore>();
             services.AddSingleton<IMonitorInfoManager, MonitorInfoManager>();
             services.AddSingleton<IMonitorStateWatcher, MonitorStateWatcher>();
             services.AddSingleton<IMonitorBrightnessStateService, MonitorBrightnessStateService>();

--- a/OLED-Sleeper/Storage/AppDataFileStore.cs
+++ b/OLED-Sleeper/Storage/AppDataFileStore.cs
@@ -1,0 +1,136 @@
+using OLED_Sleeper.Storage.Interfaces;
+using Serilog;
+using System.IO;
+using System.Text.Json;
+
+namespace OLED_Sleeper.Storage
+{
+    /// <summary>
+    /// Reads and writes JSON files under <c>%APPDATA%\OLED-Sleeper</c>.
+    /// A write is built in a temporary file and replaces the target, keeping the contents it replaced as a backup.
+    /// A read tries the target and then that backup, so an interrupted write does not lose the previous contents.
+    /// </summary>
+    public class AppDataFileStore : IAppDataFileStore
+    {
+        #region Constants
+
+        /// <summary>The folder created under the user's application data directory.</summary>
+        private const string ApplicationFolderName = "OLED-Sleeper";
+
+        /// <summary>Appended to a file name for the staging file a write is built in.</summary>
+        private const string TempFileSuffix = ".tmp";
+
+        /// <summary>Appended to a file name for the contents a write replaced.</summary>
+        private const string BackupFileSuffix = ".bak";
+
+        #endregion Constants
+
+        #region Fields
+
+        private readonly IFileSystem _fileSystem;
+
+        /// <summary>The directory every file name is resolved against.</summary>
+        private readonly string _storeDirectory;
+
+        private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
+
+        #endregion Fields
+
+        #region Constructor
+
+        /// <summary>
+        /// Resolves the store directory and creates it if it does not exist.
+        /// </summary>
+        public AppDataFileStore(IFileSystem fileSystem)
+        {
+            _fileSystem = fileSystem;
+            _storeDirectory = Path.Combine(_fileSystem.GetApplicationDataPath(), ApplicationFolderName);
+            _fileSystem.CreateDirectory(_storeDirectory);
+        }
+
+        #endregion Constructor
+
+        #region IAppDataFileStore Implementation
+
+        /// <inheritdoc />
+        public T? Read<T>(string fileName)
+        {
+            var filePath = Path.Combine(_storeDirectory, fileName);
+
+            if (TryRead<T>(filePath, out var value))
+            {
+                return value;
+            }
+
+            if (TryRead<T>(filePath + BackupFileSuffix, out var backupValue))
+            {
+                Log.Warning("Loaded {FileName} from its backup file.", fileName);
+                return backupValue;
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public bool TryWrite<T>(string fileName, T value)
+        {
+            var filePath = Path.Combine(_storeDirectory, fileName);
+            var tempFilePath = filePath + TempFileSuffix;
+
+            try
+            {
+                _fileSystem.WriteAllText(tempFilePath, JsonSerializer.Serialize(value, SerializerOptions));
+
+                if (_fileSystem.FileExists(filePath))
+                {
+                    _fileSystem.Replace(tempFilePath, filePath, filePath + BackupFileSuffix);
+                }
+                else
+                {
+                    _fileSystem.Move(tempFilePath, filePath);
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to write {FilePath}.", filePath);
+                return false;
+            }
+        }
+
+        #endregion IAppDataFileStore Implementation
+
+        #region Private Methods
+
+        /// <summary>
+        /// Reads and deserializes one file.
+        /// </summary>
+        /// <typeparam name="T">The type the contents deserialize to.</typeparam>
+        /// <param name="filePath">The full path of the file to read.</param>
+        /// <param name="value">The deserialized contents, which are <c>null</c> when the file held the JSON literal <c>null</c>.</param>
+        /// <returns><c>true</c> if the file was read and deserialized; otherwise, <c>false</c>.</returns>
+        private bool TryRead<T>(string filePath, out T? value)
+        {
+            value = default;
+
+            if (!_fileSystem.FileExists(filePath))
+            {
+                return false;
+            }
+
+            try
+            {
+                value = JsonSerializer.Deserialize<T>(_fileSystem.ReadAllText(filePath));
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to read {FilePath}.", filePath);
+                return false;
+            }
+        }
+
+        #endregion Private Methods
+    }
+}

--- a/OLED-Sleeper/Storage/FileSystem.cs
+++ b/OLED-Sleeper/Storage/FileSystem.cs
@@ -1,0 +1,35 @@
+using OLED_Sleeper.Storage.Interfaces;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+
+namespace OLED_Sleeper.Storage
+{
+    /// <summary>
+    /// Forwards every call to <see cref="File"/>, <see cref="Directory"/> and <see cref="Environment"/>.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class FileSystem : IFileSystem
+    {
+        /// <inheritdoc />
+        public string GetApplicationDataPath() => Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+
+        /// <inheritdoc />
+        public void CreateDirectory(string path) => Directory.CreateDirectory(path);
+
+        /// <inheritdoc />
+        public bool FileExists(string path) => File.Exists(path);
+
+        /// <inheritdoc />
+        public string ReadAllText(string path) => File.ReadAllText(path);
+
+        /// <inheritdoc />
+        public void WriteAllText(string path, string contents) => File.WriteAllText(path, contents);
+
+        /// <inheritdoc />
+        public void Replace(string sourcePath, string destinationPath, string backupPath)
+            => File.Replace(sourcePath, destinationPath, backupPath, ignoreMetadataErrors: true);
+
+        /// <inheritdoc />
+        public void Move(string sourcePath, string destinationPath) => File.Move(sourcePath, destinationPath);
+    }
+}

--- a/OLED-Sleeper/Storage/Interfaces/IAppDataFileStore.cs
+++ b/OLED-Sleeper/Storage/Interfaces/IAppDataFileStore.cs
@@ -1,0 +1,25 @@
+namespace OLED_Sleeper.Storage.Interfaces
+{
+    /// <summary>
+    /// Provides methods for reading and writing JSON files in the application's data directory.
+    /// </summary>
+    public interface IAppDataFileStore
+    {
+        /// <summary>
+        /// Reads a file and deserializes its contents.
+        /// </summary>
+        /// <typeparam name="T">The type the contents deserialize to.</typeparam>
+        /// <param name="fileName">The file name, with no directory part.</param>
+        /// <returns>The deserialized contents, or <c>null</c> when nothing could be read.</returns>
+        T? Read<T>(string fileName);
+
+        /// <summary>
+        /// Serializes a value and writes it to a file, replacing any existing contents.
+        /// </summary>
+        /// <typeparam name="T">The type being serialized.</typeparam>
+        /// <param name="fileName">The file name, with no directory part.</param>
+        /// <param name="value">The value to write.</param>
+        /// <returns><c>true</c> if the file was written; otherwise, <c>false</c>.</returns>
+        bool TryWrite<T>(string fileName, T value);
+    }
+}

--- a/OLED-Sleeper/Storage/Interfaces/IFileSystem.cs
+++ b/OLED-Sleeper/Storage/Interfaces/IFileSystem.cs
@@ -1,0 +1,57 @@
+namespace OLED_Sleeper.Storage.Interfaces
+{
+    /// <summary>
+    /// Wraps the file and directory calls the application makes, so callers can be tested without touching a disk.
+    /// </summary>
+    public interface IFileSystem
+    {
+        /// <summary>
+        /// Gets the roaming application data directory for the current user.
+        /// </summary>
+        /// <returns>The directory path, such as <c>C:\Users\Name\AppData\Roaming</c>.</returns>
+        string GetApplicationDataPath();
+
+        /// <summary>
+        /// Creates a directory and any missing parent. Does nothing when the directory already exists.
+        /// </summary>
+        /// <param name="path">The directory to create.</param>
+        void CreateDirectory(string path);
+
+        /// <summary>
+        /// Determines whether a file exists.
+        /// </summary>
+        /// <param name="path">The file to check.</param>
+        /// <returns><c>true</c> if the file exists; otherwise, <c>false</c>.</returns>
+        bool FileExists(string path);
+
+        /// <summary>
+        /// Reads the entire contents of a file.
+        /// </summary>
+        /// <param name="path">The file to read.</param>
+        /// <returns>The file's contents.</returns>
+        string ReadAllText(string path);
+
+        /// <summary>
+        /// Writes text to a file, overwriting any existing contents.
+        /// </summary>
+        /// <param name="path">The file to write.</param>
+        /// <param name="contents">The text to write.</param>
+        void WriteAllText(string path, string contents);
+
+        /// <summary>
+        /// Replaces one file with another, moving the replaced file's previous contents to a backup path.
+        /// The destination must already exist.
+        /// </summary>
+        /// <param name="sourcePath">The file that replaces the destination. The operation removes it.</param>
+        /// <param name="destinationPath">The file being replaced.</param>
+        /// <param name="backupPath">Where the destination's previous contents are kept.</param>
+        void Replace(string sourcePath, string destinationPath, string backupPath);
+
+        /// <summary>
+        /// Moves a file to a new path.
+        /// </summary>
+        /// <param name="sourcePath">The file to move.</param>
+        /// <param name="destinationPath">Where to move it to.</param>
+        void Move(string sourcePath, string destinationPath);
+    }
+}


### PR DESCRIPTION
JSON persistence moves into a new `Storage/` folder, and `settings.json` gains the atomic write and backup fallback that `brightness_state.json` already had.

* An interrupted `settings.json` save used to truncate the file; the load then swallowed the failure and returned empty, reverting every monitor to unmanaged defaults with no recovery path.
* No tests in this PR. The store's tests follow separately.
* `File`, `Directory` and `Environment.GetFolderPath` now appear in exactly one file, `Storage/FileSystem.cs`.
* `AppDataFileStore.TryWrite` serialises to `.tmp` and calls `File.Replace`, falling back to `File.Move` only when no target exists yet.
* `Read` tries the target, then the backup, and returns null only when neither parses.
* `SaveSettings` still gates `SettingsChanged` on a successful write, and the event still carries the supplied list rather than the merged one.
