### PR TITLE
test: cover the app data file store and its two service facades

### DIFF
--- a/OLED-Sleeper.Tests/Features/MonitorDimming/Services/MonitorBrightnessStateServiceTests.cs
+++ b/OLED-Sleeper.Tests/Features/MonitorDimming/Services/MonitorBrightnessStateServiceTests.cs
@@ -1,0 +1,61 @@
+using Moq;
+using OLED_Sleeper.Features.MonitorDimming.Services;
+using OLED_Sleeper.Storage.Interfaces;
+
+namespace OLED_Sleeper.Tests.Features.MonitorDimming.Services
+{
+    public class MonitorBrightnessStateServiceTests
+    {
+        private const string StateFileName = "brightness_state.json";
+        private const string HardwareId = "MON-PRIMARY";
+
+        private readonly Mock<IAppDataFileStore> _fileStore;
+        private readonly MonitorBrightnessStateService _service;
+
+        public MonitorBrightnessStateServiceTests()
+        {
+            _fileStore = new Mock<IAppDataFileStore>();
+            _service = new MonitorBrightnessStateService(_fileStore.Object);
+        }
+
+        [Fact]
+        public void LoadState_WhenTheStoreHasAState_ReturnsIt()
+        {
+            // Arrange
+            _fileStore.Setup(s => s.Read<Dictionary<string, uint>>(StateFileName))
+                .Returns(new Dictionary<string, uint> { [HardwareId] = 80 });
+
+            // Act
+            var state = _service.LoadState();
+
+            // Assert
+            Assert.Equal(80u, state[HardwareId]);
+        }
+
+        [Fact]
+        public void LoadState_WhenNothingCouldBeRead_ReturnsAnEmptyDictionary()
+        {
+            // Arrange
+            _fileStore.Setup(s => s.Read<Dictionary<string, uint>>(StateFileName)).Returns((Dictionary<string, uint>?)null);
+
+            // Act
+            var state = _service.LoadState();
+
+            // Assert
+            Assert.Empty(state);
+        }
+
+        [Fact]
+        public void SaveState_WhenCalled_WritesTheStateUnderTheStateFileName()
+        {
+            // Arrange
+            var state = new Dictionary<string, uint> { [HardwareId] = 80 };
+
+            // Act
+            _service.SaveState(state);
+
+            // Assert
+            _fileStore.Verify(s => s.TryWrite(StateFileName, state), Times.Once);
+        }
+    }
+}

--- a/OLED-Sleeper.Tests/Features/UserSettings/Services/MonitorSettingsFileServiceTests.cs
+++ b/OLED-Sleeper.Tests/Features/UserSettings/Services/MonitorSettingsFileServiceTests.cs
@@ -1,0 +1,143 @@
+using Moq;
+using OLED_Sleeper.Features.UserSettings.Models;
+using OLED_Sleeper.Features.UserSettings.Services;
+using OLED_Sleeper.Storage.Interfaces;
+
+namespace OLED_Sleeper.Tests.Features.UserSettings.Services
+{
+    public class MonitorSettingsFileServiceTests
+    {
+        private const string SettingsFileName = "settings.json";
+
+        private readonly Mock<IAppDataFileStore> _fileStore;
+        private readonly MonitorSettingsFileService _service;
+
+        public MonitorSettingsFileServiceTests()
+        {
+            _fileStore = new Mock<IAppDataFileStore>();
+            _fileStore.Setup(s => s.TryWrite(SettingsFileName, It.IsAny<List<MonitorSettings>>())).Returns(true);
+            _service = new MonitorSettingsFileService(_fileStore.Object);
+        }
+
+        [Fact]
+        public void LoadSettings_WhenTheStoreHasSettings_ReturnsThem()
+        {
+            // Arrange
+            SetupStoredSettings(Settings("A"));
+
+            // Act
+            var settings = _service.LoadSettings();
+
+            // Assert
+            Assert.Equal("A", Assert.Single(settings).HardwareId);
+        }
+
+        [Fact]
+        public void LoadSettings_WhenNothingCouldBeRead_ReturnsAnEmptyList()
+        {
+            // Act
+            var settings = _service.LoadSettings();
+
+            // Assert
+            Assert.Empty(settings);
+        }
+
+        [Fact]
+        public void SaveSettings_WhenAStoredMonitorWasNotSupplied_KeepsItsSettings()
+        {
+            // Arrange
+            SetupStoredSettings(Settings("A"), Settings("B"));
+
+            // Act
+            _service.SaveSettings(new List<MonitorSettings> { Settings("A") });
+
+            // Assert
+            VerifyWritten(written => written.Count == 2 && written.Any(m => m.HardwareId == "B"));
+        }
+
+        [Fact]
+        public void SaveSettings_WhenAStoredMonitorWasSupplied_WritesOnlyTheSuppliedCopy()
+        {
+            // Arrange
+            SetupStoredSettings(Settings("A", dimLevel: 15));
+
+            // Act
+            _service.SaveSettings(new List<MonitorSettings> { Settings("A", dimLevel: 50) });
+
+            // Assert
+            VerifyWritten(written => written.Count == 1 && written.Single().DimLevel == 50);
+        }
+
+        [Fact]
+        public void SaveSettings_WhenNothingIsStored_WritesTheSuppliedSettings()
+        {
+            // Act
+            _service.SaveSettings(new List<MonitorSettings> { Settings("A") });
+
+            // Assert
+            VerifyWritten(written => written.Count == 1 && written.Single().HardwareId == "A");
+        }
+
+        [Fact]
+        public void SaveSettings_WhenTheWriteSucceeds_RaisesSettingsChangedWithTheSuppliedSettings()
+        {
+            // Arrange
+            SetupStoredSettings(Settings("A"), Settings("B"));
+            var supplied = new List<MonitorSettings> { Settings("A") };
+            List<MonitorSettings>? raised = null;
+            _service.SettingsChanged += settings => raised = settings;
+
+            // Act
+            _service.SaveSettings(supplied);
+
+            // Assert
+            Assert.Same(supplied, raised);
+        }
+
+        [Fact]
+        public void SaveSettings_WhenTheWriteFails_DoesNotRaiseSettingsChanged()
+        {
+            // Arrange
+            _fileStore.Setup(s => s.TryWrite(SettingsFileName, It.IsAny<List<MonitorSettings>>())).Returns(false);
+            var raised = false;
+            _service.SettingsChanged += _ => raised = true;
+
+            // Act
+            _service.SaveSettings(new List<MonitorSettings> { Settings("A") });
+
+            // Assert
+            Assert.False(raised);
+        }
+
+        [Fact]
+        public void SaveSettings_WhenASubscriberThrows_DoesNotPropagate()
+        {
+            // Arrange
+            _service.SettingsChanged += _ => throw new InvalidOperationException("Subscriber failed.");
+
+            // Act
+            var exception = Record.Exception(() => _service.SaveSettings(new List<MonitorSettings> { Settings("A") }));
+
+            // Assert
+            Assert.Null(exception);
+        }
+
+        /// <summary>
+        /// Builds a settings entry for the given monitor.
+        /// </summary>
+        private static MonitorSettings Settings(string hardwareId, double dimLevel = 15)
+            => new() { HardwareId = hardwareId, DimLevel = dimLevel };
+
+        /// <summary>
+        /// Makes the store report the given entries as already on disk.
+        /// </summary>
+        private void SetupStoredSettings(params MonitorSettings[] stored)
+            => _fileStore.Setup(s => s.Read<List<MonitorSettings>>(SettingsFileName)).Returns(stored.ToList());
+
+        /// <summary>
+        /// Asserts that exactly one write happened and that the list it carried satisfies the predicate.
+        /// </summary>
+        private void VerifyWritten(Func<List<MonitorSettings>, bool> predicate)
+            => _fileStore.Verify(s => s.TryWrite(SettingsFileName, It.Is<List<MonitorSettings>>(w => predicate(w))), Times.Once);
+    }
+}

--- a/OLED-Sleeper.Tests/OLED-Sleeper.Tests.csproj
+++ b/OLED-Sleeper.Tests/OLED-Sleeper.Tests.csproj
@@ -27,8 +27,4 @@
 	<Using Include="Xunit" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <Folder Include="Features\MonitorBlackout\Services\" />
-	</ItemGroup>
-
 </Project>

--- a/OLED-Sleeper.Tests/Storage/AppDataFileStoreTests.cs
+++ b/OLED-Sleeper.Tests/Storage/AppDataFileStoreTests.cs
@@ -1,0 +1,184 @@
+using OLED_Sleeper.Storage;
+using OLED_Sleeper.Tests.TestDoubles;
+
+namespace OLED_Sleeper.Tests.Storage
+{
+    public class AppDataFileStoreTests
+    {
+        private const string FileName = "state.json";
+        private const string StoreDirectory = @"C:\FakeAppData\OLED-Sleeper";
+        private const string TargetPath = StoreDirectory + @"\" + FileName;
+        private const string BackupPath = TargetPath + ".bak";
+        private const string TempPath = TargetPath + ".tmp";
+
+        private readonly FakeFileSystem _fileSystem;
+        private readonly AppDataFileStore _store;
+
+        public AppDataFileStoreTests()
+        {
+            _fileSystem = new FakeFileSystem();
+            _store = new AppDataFileStore(_fileSystem);
+        }
+
+        [Fact]
+        public void Constructor_WhenBuilt_CreatesTheStoreDirectoryOnce()
+        {
+            // Assert
+            Assert.Equal(new[] { StoreDirectory }, _fileSystem.CreatedDirectories);
+        }
+
+        [Fact]
+        public void Read_WhenTheTargetParses_ReturnsItsContents()
+        {
+            // Arrange
+            _fileSystem.AddFile(TargetPath, """{ "A": 40 }""");
+
+            // Act
+            var state = _store.Read<Dictionary<string, uint>>(FileName);
+
+            // Assert
+            Assert.NotNull(state);
+            Assert.Equal(40u, state["A"]);
+        }
+
+        [Fact]
+        public void Read_WhenTheTargetIsMissing_ReadsTheBackup()
+        {
+            // Arrange
+            _fileSystem.AddFile(BackupPath, """{ "A": 40 }""");
+
+            // Act
+            var state = _store.Read<Dictionary<string, uint>>(FileName);
+
+            // Assert
+            Assert.NotNull(state);
+            Assert.Equal(40u, state["A"]);
+        }
+
+        [Fact]
+        public void Read_WhenTheTargetIsTruncated_ReadsTheBackup()
+        {
+            // Arrange
+            _fileSystem.AddFile(TargetPath, """{ "A": """);
+            _fileSystem.AddFile(BackupPath, """{ "A": 40 }""");
+
+            // Act
+            var state = _store.Read<Dictionary<string, uint>>(FileName);
+
+            // Assert
+            Assert.NotNull(state);
+            Assert.Equal(40u, state["A"]);
+        }
+
+        [Fact]
+        public void Read_WhenNeitherFileParses_ReturnsNull()
+        {
+            // Arrange
+            _fileSystem.AddFile(TargetPath, """{ "A": """);
+            _fileSystem.AddFile(BackupPath, """{ "A": """);
+
+            // Act
+            var state = _store.Read<Dictionary<string, uint>>(FileName);
+
+            // Assert
+            Assert.Null(state);
+        }
+
+        [Fact]
+        public void Read_WhenNeitherFileExists_ReturnsNull()
+        {
+            // Act
+            var state = _store.Read<Dictionary<string, uint>>(FileName);
+
+            // Assert
+            Assert.Null(state);
+        }
+
+        [Fact]
+        public void Read_WhenTheTargetHoldsJsonNull_ReturnsNullWithoutReadingTheBackup()
+        {
+            // Arrange
+            _fileSystem.AddFile(TargetPath, "null");
+            _fileSystem.AddFile(BackupPath, """{ "A": 40 }""");
+
+            // Act
+            var state = _store.Read<Dictionary<string, uint>>(FileName);
+
+            // Assert
+            Assert.Null(state);
+        }
+
+        [Fact]
+        public void TryWrite_WhenNoTargetExists_MovesTheTemporaryFileOntoIt()
+        {
+            // Act
+            var written = _store.TryWrite(FileName, new Dictionary<string, uint> { ["A"] = 40 });
+
+            // Assert
+            Assert.True(written);
+            Assert.Contains("\"A\": 40", _fileSystem.Contents(TargetPath)!);
+            Assert.Null(_fileSystem.Contents(BackupPath));
+            Assert.Null(_fileSystem.Contents(TempPath));
+        }
+
+        [Fact]
+        public void TryWrite_WhenTheTargetExists_ReplacesItAndKeepsTheOldContentsAsBackup()
+        {
+            // Arrange
+            _fileSystem.AddFile(TargetPath, """{ "A": 40 }""");
+
+            // Act
+            var written = _store.TryWrite(FileName, new Dictionary<string, uint> { ["A"] = 5 });
+
+            // Assert
+            Assert.True(written);
+            Assert.Contains("\"A\": 5", _fileSystem.Contents(TargetPath)!);
+            Assert.Equal("""{ "A": 40 }""", _fileSystem.Contents(BackupPath));
+            Assert.Null(_fileSystem.Contents(TempPath));
+        }
+
+        [Fact]
+        public void TryWrite_WhenTheTemporaryWriteFails_ReturnsFalseAndLeavesTheTargetAlone()
+        {
+            // Arrange
+            _fileSystem.AddFile(TargetPath, """{ "A": 40 }""");
+            _fileSystem.WritesFail = true;
+
+            // Act
+            var written = _store.TryWrite(FileName, new Dictionary<string, uint> { ["A"] = 5 });
+
+            // Assert
+            Assert.False(written);
+            Assert.Equal("""{ "A": 40 }""", _fileSystem.Contents(TargetPath));
+        }
+
+        [Fact]
+        public void TryWrite_WhenTheReplaceFails_ReturnsFalseAndLeavesTheTargetAlone()
+        {
+            // Arrange
+            _fileSystem.AddFile(TargetPath, """{ "A": 40 }""");
+            _fileSystem.ReplaceFails = true;
+
+            // Act
+            var written = _store.TryWrite(FileName, new Dictionary<string, uint> { ["A"] = 5 });
+
+            // Assert
+            Assert.False(written);
+            Assert.Equal("""{ "A": 40 }""", _fileSystem.Contents(TargetPath));
+        }
+
+        [Fact]
+        public void TryWrite_WhenReadBack_ReturnsTheSameValue()
+        {
+            // Arrange
+            _store.TryWrite(FileName, new Dictionary<string, uint> { ["A"] = 40 });
+
+            // Act
+            var state = _store.Read<Dictionary<string, uint>>(FileName);
+
+            // Assert
+            Assert.NotNull(state);
+            Assert.Equal(40u, state["A"]);
+        }
+    }
+}

--- a/OLED-Sleeper.Tests/TestDoubles/FakeFileSystem.cs
+++ b/OLED-Sleeper.Tests/TestDoubles/FakeFileSystem.cs
@@ -1,0 +1,95 @@
+using OLED_Sleeper.Storage.Interfaces;
+using System.IO;
+
+namespace OLED_Sleeper.Tests.TestDoubles
+{
+    /// <summary>
+    /// An <see cref="IFileSystem"/> over a dictionary of paths and contents, holding no real files.
+    /// <see cref="Replace"/> and <see cref="Move"/> reject the same calls the Win32 originals reject, so a
+    /// caller that picks the wrong one of the two fails here instead of quietly passing.
+    /// <see cref="ReadsFail"/>, <see cref="WritesFail"/> and <see cref="ReplaceFails"/> script the failures
+    /// the store's catch blocks exist for.
+    /// </summary>
+    public class FakeFileSystem : IFileSystem
+    {
+        private readonly Dictionary<string, string> _files = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>The root <see cref="GetApplicationDataPath"/> reports.</summary>
+        public string ApplicationDataPath { get; set; } = @"C:\FakeAppData";
+
+        /// <summary>Every path <see cref="CreateDirectory"/> was called with, in order.</summary>
+        public List<string> CreatedDirectories { get; } = new();
+
+        /// <summary>Makes every <see cref="ReadAllText"/> call throw.</summary>
+        public bool ReadsFail { get; set; }
+
+        /// <summary>Makes every <see cref="WriteAllText"/> call throw.</summary>
+        public bool WritesFail { get; set; }
+
+        /// <summary>Makes every <see cref="Replace"/> call throw.</summary>
+        public bool ReplaceFails { get; set; }
+
+        /// <summary>
+        /// Puts a file in place without going through <see cref="WriteAllText"/>, so arranging a fixture is
+        /// not affected by <see cref="WritesFail"/>.
+        /// </summary>
+        /// <param name="path">The full path of the file.</param>
+        /// <param name="contents">The contents to store.</param>
+        public void AddFile(string path, string contents) => _files[path] = contents;
+
+        /// <summary>
+        /// Reads a file's contents without going through <see cref="ReadAllText"/>.
+        /// </summary>
+        /// <param name="path">The full path of the file.</param>
+        /// <returns>The contents, or <c>null</c> when no such file exists.</returns>
+        public string? Contents(string path) => _files.TryGetValue(path, out var contents) ? contents : null;
+
+        /// <inheritdoc />
+        public string GetApplicationDataPath() => ApplicationDataPath;
+
+        /// <inheritdoc />
+        public void CreateDirectory(string path) => CreatedDirectories.Add(path);
+
+        /// <inheritdoc />
+        public bool FileExists(string path) => _files.ContainsKey(path);
+
+        /// <inheritdoc />
+        public string ReadAllText(string path)
+        {
+            if (ReadsFail) throw new IOException($"Reads are failing: {path}.");
+            if (!_files.TryGetValue(path, out var contents)) throw new FileNotFoundException(path);
+
+            return contents;
+        }
+
+        /// <inheritdoc />
+        public void WriteAllText(string path, string contents)
+        {
+            if (WritesFail) throw new IOException($"Writes are failing: {path}.");
+
+            _files[path] = contents;
+        }
+
+        /// <inheritdoc />
+        public void Replace(string sourcePath, string destinationPath, string backupPath)
+        {
+            if (ReplaceFails) throw new IOException($"Replaces are failing: {destinationPath}.");
+            if (!_files.ContainsKey(sourcePath)) throw new FileNotFoundException(sourcePath);
+            if (!_files.ContainsKey(destinationPath)) throw new FileNotFoundException(destinationPath);
+
+            _files[backupPath] = _files[destinationPath];
+            _files[destinationPath] = _files[sourcePath];
+            _files.Remove(sourcePath);
+        }
+
+        /// <inheritdoc />
+        public void Move(string sourcePath, string destinationPath)
+        {
+            if (!_files.ContainsKey(sourcePath)) throw new FileNotFoundException(sourcePath);
+            if (_files.ContainsKey(destinationPath)) throw new IOException($"Already exists: {destinationPath}.");
+
+            _files[destinationPath] = _files[sourcePath];
+            _files.Remove(sourcePath);
+        }
+    }
+}


### PR DESCRIPTION
23 tests over `AppDataFileStore` and the two service facades that sit on it.

* `FakeFileSystem` is strict: `Replace` throws without a destination and `Move` throws with one, as Win32 does. Invert the branch in `TryWrite` and both write tests fail; a permissive fake would pin nothing.
* Nothing touches a disk, so the suite keeps that property.
* A target holding the JSON literal `null` returns null without consulting the backup.
* `MonitorSettingsFileService` had no test of any kind before this. The merge is now pinned in both directions.
* `SettingsChanged` carries the supplied list rather than the merged one, and a throwing subscriber does not propagate. That pins the guard recorded in `ui-and-settings.md`.
* The write path is covered end to end: `Move` with no target, `Replace` with one and the old contents landing in `.bak`, and no `.tmp` left behind when either fails.
