### PR TITLE
refactor: decompose MainViewModel and fix the save-time restore

### DIFF
--- a/OLED-Sleeper.Tests/UI/Services/MonitorSettingsSaveServiceTests.cs
+++ b/OLED-Sleeper.Tests/UI/Services/MonitorSettingsSaveServiceTests.cs
@@ -1,0 +1,159 @@
+using Moq;
+using OLED_Sleeper.Features.MonitorBehavior.Models;
+using OLED_Sleeper.Features.MonitorInformation.Models;
+using OLED_Sleeper.Features.UserSettings.Models;
+using OLED_Sleeper.Features.UserSettings.Services.Interfaces;
+using OLED_Sleeper.UI.Models;
+using OLED_Sleeper.UI.Services;
+using OLED_Sleeper.UI.Services.Interfaces;
+using OLED_Sleeper.UI.ViewModels;
+using System.Windows;
+
+namespace OLED_Sleeper.Tests.UI.Services
+{
+    public class MonitorSettingsSaveServiceTests
+    {
+        private readonly Mock<IMonitorSettingsFileService> _settingsServiceMock;
+        private readonly Mock<IDialogService> _dialogServiceMock;
+        private readonly MonitorSettingsSaveService _service;
+
+        /// <summary>The settings handed to the settings file service, or null when it was never called.</summary>
+        private List<MonitorSettings>? _writtenSettings;
+
+        public MonitorSettingsSaveServiceTests()
+        {
+            _settingsServiceMock = new Mock<IMonitorSettingsFileService>();
+            _dialogServiceMock = new Mock<IDialogService>();
+
+            _settingsServiceMock
+                .Setup(x => x.SaveSettings(It.IsAny<List<MonitorSettings>>()))
+                .Callback<List<MonitorSettings>>(settings => _writtenSettings = settings);
+
+            _service = new MonitorSettingsSaveService(
+                _settingsServiceMock.Object,
+                _dialogServiceMock.Object);
+        }
+
+        [Fact]
+        public void TrySave_WhenSettingsAreValid_WritesThemAndReportsSuccess()
+        {
+            // Arrange
+            var monitor = CreateManagedMonitor("MON-1");
+            monitor.Configuration.DimLevel = 50;
+
+            // Act
+            var saved = _service.TrySave(new[] { monitor });
+
+            // Assert
+            Assert.True(saved);
+            Assert.NotNull(_writtenSettings);
+            var entry = Assert.Single(_writtenSettings!);
+            Assert.Equal("MON-1", entry.HardwareId);
+            Assert.Equal(50, entry.DimLevel);
+        }
+
+        [Fact]
+        public void TrySave_WhenSettingsAreValid_MarksEveryMonitorAsSaved()
+        {
+            // Arrange
+            var first = CreateManagedMonitor("MON-1");
+            var second = CreateManagedMonitor("MON-2", 2);
+            first.Configuration.DimLevel = 50;
+            Assert.True(first.Configuration.IsDirty);
+
+            // Act
+            _service.TrySave(new[] { first, second });
+
+            // Assert
+            Assert.False(first.Configuration.IsDirty);
+            Assert.False(second.Configuration.IsDirty);
+        }
+
+        [Fact]
+        public void TrySave_WhenAManagedMonitorIsInvalid_ShowsTheErrorAndWritesNothing()
+        {
+            // Arrange
+            var monitor = CreateManagedMonitor("MON-1");
+            monitor.Configuration.IdleValue = 0;
+
+            // Act
+            var saved = _service.TrySave(new[] { monitor });
+
+            // Assert
+            Assert.False(saved);
+            _dialogServiceMock.Verify(x => x.ShowError(It.IsAny<string>(), "Monitor Configuration Error"), Times.Once);
+            _settingsServiceMock.Verify(x => x.SaveSettings(It.IsAny<List<MonitorSettings>>()), Times.Never);
+        }
+
+        [Fact]
+        public void TrySave_WhenAMonitorIsInvalidButUnmanaged_SavesAnyway()
+        {
+            // Arrange
+            var monitor = CreateMonitor("MON-1");
+            monitor.Configuration.IdleValue = 0;
+
+            // Act
+            var saved = _service.TrySave(new[] { monitor });
+
+            // Assert
+            Assert.True(saved);
+            _dialogServiceMock.Verify(x => x.ShowError(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            _settingsServiceMock.Verify(x => x.SaveSettings(It.IsAny<List<MonitorSettings>>()), Times.Once);
+        }
+
+        [Fact]
+        public void TrySave_WithNoMonitors_WritesAnEmptyList()
+        {
+            // Act
+            var saved = _service.TrySave(Array.Empty<MonitorLayoutViewModel>());
+
+            // Assert
+            Assert.True(saved);
+            Assert.NotNull(_writtenSettings);
+            Assert.Empty(_writtenSettings!);
+        }
+
+        /// <summary>
+        /// Builds a managed monitor whose configuration is otherwise valid.
+        /// </summary>
+        /// <param name="hardwareId">The hardware ID for the monitor.</param>
+        /// <param name="displayNumber">The display number for the monitor.</param>
+        /// <returns>A layout view model over the described monitor.</returns>
+        private static MonitorLayoutViewModel CreateManagedMonitor(string hardwareId, int displayNumber = 1)
+        {
+            var monitor = CreateMonitor(hardwareId, displayNumber);
+            monitor.Configuration.ApplySettings(new MonitorSettings
+            {
+                HardwareId = hardwareId,
+                IsManaged = true,
+                Behavior = MonitorBehaviorType.Blackout,
+                IdleValue = 5,
+                IdleUnit = TimeUnit.Minutes,
+                IsActiveOnInput = true
+            });
+            monitor.Configuration.MarkAsSaved();
+
+            return monitor;
+        }
+
+        /// <summary>
+        /// Builds a layout view model over a 1920x1080 monitor with the supplied hardware ID.
+        /// </summary>
+        /// <param name="hardwareId">The hardware ID for the monitor.</param>
+        /// <param name="displayNumber">The display number for the monitor.</param>
+        /// <returns>A layout view model over the described monitor.</returns>
+        private static MonitorLayoutViewModel CreateMonitor(string hardwareId, int displayNumber = 1)
+        {
+            var bounds = new Rect(0, 0, 1920, 1080);
+            var monitorInfo = new MonitorInfo
+            {
+                HardwareId = hardwareId,
+                DisplayNumber = displayNumber,
+                DeviceName = $@"\\.\DISPLAY{displayNumber}",
+                Bounds = bounds
+            };
+
+            return new MonitorLayoutViewModel(monitorInfo, 1.0, bounds, 0, 0);
+        }
+    }
+}

--- a/OLED-Sleeper.Tests/UI/ViewModels/MainViewModelTests.cs
+++ b/OLED-Sleeper.Tests/UI/ViewModels/MainViewModelTests.cs
@@ -2,7 +2,6 @@ using Moq;
 using OLED_Sleeper.Features.MonitorInformation.Models;
 using OLED_Sleeper.Features.UserSettings.Models;
 using OLED_Sleeper.Features.UserSettings.Services.Interfaces;
-using OLED_Sleeper.Messaging.Interfaces;
 using OLED_Sleeper.Tests.TestDoubles;
 using OLED_Sleeper.UI.Services.Interfaces;
 using OLED_Sleeper.UI.ViewModels;
@@ -17,7 +16,6 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         private readonly Mock<IMonitorSettingsFileService> _settingsServiceMock;
         private readonly Mock<IMainWindowAccessor> _mainWindowAccessorMock;
         private readonly Mock<IDialogService> _dialogServiceMock;
-        private readonly Mock<IMediator> _mediatorMock;
         private readonly ImmediateDispatcher _dispatcher;
         private readonly MainViewModel _viewModel;
 
@@ -27,7 +25,6 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
             _settingsServiceMock = new Mock<IMonitorSettingsFileService>();
             _mainWindowAccessorMock = new Mock<IMainWindowAccessor>();
             _dialogServiceMock = new Mock<IDialogService>();
-            _mediatorMock = new Mock<IMediator>();
             _dispatcher = new ImmediateDispatcher();
 
             _workspaceServiceMock
@@ -42,8 +39,7 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
                 _settingsServiceMock.Object,
                 _dispatcher,
                 _mainWindowAccessorMock.Object,
-                _dialogServiceMock.Object,
-                _mediatorMock.Object);
+                _dialogServiceMock.Object);
         }
 
         [Fact]

--- a/OLED-Sleeper.Tests/UI/ViewModels/MainViewModelTests.cs
+++ b/OLED-Sleeper.Tests/UI/ViewModels/MainViewModelTests.cs
@@ -13,7 +13,7 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
     public class MainViewModelTests
     {
         private readonly Mock<IWorkspaceService> _workspaceServiceMock;
-        private readonly Mock<IMonitorSettingsFileService> _settingsServiceMock;
+        private readonly Mock<IMonitorSettingsSaveService> _saveServiceMock;
         private readonly Mock<IMainWindowAccessor> _mainWindowAccessorMock;
         private readonly Mock<IDialogService> _dialogServiceMock;
         private readonly ImmediateDispatcher _dispatcher;
@@ -22,16 +22,17 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         public MainViewModelTests()
         {
             _workspaceServiceMock = new Mock<IWorkspaceService>();
-            _settingsServiceMock = new Mock<IMonitorSettingsFileService>();
+            _saveServiceMock = new Mock<IMonitorSettingsSaveService>();
             _mainWindowAccessorMock = new Mock<IMainWindowAccessor>();
             _dialogServiceMock = new Mock<IDialogService>();
             _dispatcher = new ImmediateDispatcher();
 
             SetupWorkspace();
+            SetupSaveOutcome(true);
 
             _viewModel = new MainViewModel(
                 _workspaceServiceMock.Object,
-                _settingsServiceMock.Object,
+                _saveServiceMock.Object,
                 _dispatcher,
                 _mainWindowAccessorMock.Object,
                 _dialogServiceMock.Object);
@@ -341,7 +342,7 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
             // Assert
             Assert.False(shouldClose);
             _mainWindowAccessorMock.Verify(x => x.HideMainWindow(), Times.Never);
-            _settingsServiceMock.Verify(x => x.SaveSettings(It.IsAny<List<MonitorSettings>>()), Times.Never);
+            _saveServiceMock.Verify(x => x.TrySave(It.IsAny<IReadOnlyList<MonitorLayoutViewModel>>()), Times.Never);
         }
 
         [Fact]
@@ -358,7 +359,7 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
 
             // Assert
             Assert.False(shouldClose);
-            _settingsServiceMock.Verify(x => x.SaveSettings(It.IsAny<List<MonitorSettings>>()), Times.Once);
+            _saveServiceMock.Verify(x => x.TrySave(It.IsAny<IReadOnlyList<MonitorLayoutViewModel>>()), Times.Once);
             _mainWindowAccessorMock.Verify(x => x.HideMainWindow(), Times.Once);
         }
 
@@ -374,12 +375,12 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
 
             // Assert
             Assert.False(shouldClose);
-            _settingsServiceMock.Verify(x => x.SaveSettings(It.IsAny<List<MonitorSettings>>()), Times.Never);
+            _saveServiceMock.Verify(x => x.TrySave(It.IsAny<IReadOnlyList<MonitorLayoutViewModel>>()), Times.Never);
             _mainWindowAccessorMock.Verify(x => x.HideMainWindow(), Times.Once);
         }
 
         [Fact]
-        public void SaveSettingsCommand_WhenSettingsValid_SavesAndClearsDirtyState()
+        public void SaveSettingsCommand_WhenSaveSucceeds_ClearsDirtyStateAndConfirmsOnTheButton()
         {
             // Arrange
             var monitor = CreateMonitor("MON-1");
@@ -387,37 +388,28 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
             monitor.Configuration.DimLevel = 50;
             Assert.True(_viewModel.IsDirty);
 
-            List<MonitorSettings>? saved = null;
-            _settingsServiceMock
-                .Setup(x => x.SaveSettings(It.IsAny<List<MonitorSettings>>()))
-                .Callback<List<MonitorSettings>>(settings => saved = settings);
-
             // Act
             _viewModel.SaveSettingsCommand.Execute(null);
 
             // Assert
-            Assert.NotNull(saved);
-            var entry = Assert.Single(saved!);
-            Assert.Equal("MON-1", entry.HardwareId);
-            Assert.Equal(50, entry.DimLevel);
+            _saveServiceMock.Verify(x => x.TrySave(_viewModel.Monitors), Times.Once);
             Assert.False(_viewModel.IsDirty);
             Assert.Equal("Saved!", _viewModel.SaveButtonText);
         }
 
         [Fact]
-        public void SaveSettingsCommand_WhenSettingsInvalid_ShowsErrorAndDoesNotSave()
+        public void SaveSettingsCommand_WhenSaveIsRejected_KeepsDirtyStateAndLeavesTheButtonAlone()
         {
             // Arrange
             var monitor = CreateMonitor("MON-1");
             LoadMonitors(monitor);
-            monitor.Configuration.IsManaged = true;
+            monitor.Configuration.DimLevel = 50;
+            SetupSaveOutcome(false);
 
             // Act
             _viewModel.SaveSettingsCommand.Execute(null);
 
             // Assert
-            _dialogServiceMock.Verify(x => x.ShowError(It.IsAny<string>(), "Monitor Configuration Error"), Times.Once);
-            _settingsServiceMock.Verify(x => x.SaveSettings(It.IsAny<List<MonitorSettings>>()), Times.Never);
             Assert.Equal("Save Settings", _viewModel.SaveButtonText);
             Assert.True(_viewModel.IsDirty);
         }
@@ -489,6 +481,28 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         {
             SetupWorkspace(monitors);
             _viewModel.RecalculateLayout(800, 600);
+        }
+
+        /// <summary>
+        /// Makes the save service accept or reject the settings. A successful save marks each monitor
+        /// as saved, as the real service does.
+        /// </summary>
+        /// <param name="succeeds">Whether the save service should report the settings as written.</param>
+        private void SetupSaveOutcome(bool succeeds)
+        {
+            _saveServiceMock
+                .Setup(x => x.TrySave(It.IsAny<IReadOnlyList<MonitorLayoutViewModel>>()))
+                .Returns<IReadOnlyList<MonitorLayoutViewModel>>(monitors =>
+                {
+                    if (!succeeds) return false;
+
+                    foreach (var monitor in monitors)
+                    {
+                        monitor.Configuration.MarkAsSaved();
+                    }
+
+                    return true;
+                });
         }
 
         /// <summary>

--- a/OLED-Sleeper.Tests/UI/ViewModels/MainViewModelTests.cs
+++ b/OLED-Sleeper.Tests/UI/ViewModels/MainViewModelTests.cs
@@ -182,6 +182,21 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         }
 
         [Fact]
+        public void RecalculateLayout_WhenAReplacedMonitorChanges_LeavesTheViewModelClean()
+        {
+            // Arrange
+            var replaced = CreateMonitor("MON-1");
+            LoadMonitors(replaced);
+            LoadMonitors(CreateMonitor("MON-2", 2));
+
+            // Act
+            replaced.Configuration.DimLevel = 50;
+
+            // Assert
+            Assert.False(_viewModel.IsDirty);
+        }
+
+        [Fact]
         public void IsDirty_WhenSetToSameValue_RaisesNoFurtherNotification()
         {
             // Arrange

--- a/OLED-Sleeper.Tests/UI/ViewModels/MainViewModelTests.cs
+++ b/OLED-Sleeper.Tests/UI/ViewModels/MainViewModelTests.cs
@@ -27,12 +27,7 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
             _dialogServiceMock = new Mock<IDialogService>();
             _dispatcher = new ImmediateDispatcher();
 
-            _workspaceServiceMock
-                .Setup(x => x.BuildWorkspaceAsync(It.IsAny<double>(), It.IsAny<double>()))
-                .Returns(Task.CompletedTask);
-            _workspaceServiceMock
-                .Setup(x => x.RefreshWorkspaceAsync(It.IsAny<double>(), It.IsAny<double>()))
-                .Returns(Task.CompletedTask);
+            SetupWorkspace();
 
             _viewModel = new MainViewModel(
                 _workspaceServiceMock.Object,
@@ -43,42 +38,42 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         }
 
         [Fact]
-        public void WorkspaceReady_PopulatesMonitors()
+        public void RecalculateLayout_PopulatesMonitors()
         {
             // Arrange
             var first = CreateMonitor("MON-1");
             var second = CreateMonitor("MON-2", 2);
 
             // Act
-            RaiseWorkspaceReady(first, second);
+            LoadMonitors(first, second);
 
             // Assert
             Assert.Equal(new[] { first, second }, _viewModel.Monitors);
         }
 
         [Fact]
-        public void WorkspaceReady_WhenRaisedAgain_ReplacesPreviousMonitors()
+        public void RecalculateLayout_WhenBuiltAgain_ReplacesPreviousMonitors()
         {
             // Arrange
-            RaiseWorkspaceReady(CreateMonitor("MON-1"), CreateMonitor("MON-2", 2));
+            LoadMonitors(CreateMonitor("MON-1"), CreateMonitor("MON-2", 2));
             var replacement = CreateMonitor("MON-3", 3);
 
             // Act
-            RaiseWorkspaceReady(replacement);
+            LoadMonitors(replacement);
 
             // Assert
             Assert.Equal(new[] { replacement }, _viewModel.Monitors);
         }
 
         [Fact]
-        public void WorkspaceReady_WhenNotOnUiThread_MarshalsOnceAndStillPopulates()
+        public void RecalculateLayout_WhenNotOnUiThread_MarshalsOnceAndStillPopulates()
         {
             // Arrange
             _dispatcher.IsOnUiThread = false;
             var monitor = CreateMonitor("MON-1");
 
             // Act
-            RaiseWorkspaceReady(monitor);
+            LoadMonitors(monitor);
 
             // Assert
             Assert.Equal(new[] { monitor }, _viewModel.Monitors);
@@ -86,13 +81,13 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         }
 
         [Fact]
-        public void WorkspaceReady_WhenOnUiThread_DoesNotUseDispatcher()
+        public void RecalculateLayout_WhenOnUiThread_DoesNotUseDispatcher()
         {
             // Arrange
             var monitor = CreateMonitor("MON-1");
 
             // Act
-            RaiseWorkspaceReady(monitor);
+            LoadMonitors(monitor);
 
             // Assert
             Assert.Equal(new[] { monitor }, _viewModel.Monitors);
@@ -100,31 +95,53 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         }
 
         [Fact]
-        public void WorkspaceReady_ClearsLoadingFlag()
+        public async Task RecalculateLayout_SetsLoadingWhileBuildingAndClearsItWhenDone()
         {
             // Arrange
-            _viewModel.RecalculateLayout(800, 600);
-            Assert.True(_viewModel.IsLoading);
+            var pendingBuild = SetupPendingBuild();
 
             // Act
-            RaiseWorkspaceReady(CreateMonitor("MON-1"));
+            _viewModel.RecalculateLayout(800, 600);
+            var loadingWhileBuilding = _viewModel.IsLoading;
+            pendingBuild.SetResult(Collect(CreateMonitor("MON-1")));
+            await pendingBuild.Task;
 
             // Assert
+            Assert.True(loadingWhileBuilding);
             Assert.False(_viewModel.IsLoading);
         }
 
         [Fact]
-        public void WorkspaceReady_WhenSelectionPreserved_RestoresSelectedMonitorByHardwareId()
+        public async Task RecalculateLayout_WhenSupersededByANewerBuild_DiscardsTheStaleResult()
+        {
+            // Arrange
+            var stale = CreateMonitor("STALE");
+            var current = CreateMonitor("CURRENT");
+            var pendingBuild = SetupPendingBuild();
+            _viewModel.RecalculateLayout(800, 600);
+
+            // Act
+            SetupWorkspace(current);
+            _viewModel.RecalculateLayout(1024, 768);
+            pendingBuild.SetResult(Collect(stale));
+            await pendingBuild.Task;
+
+            // Assert
+            Assert.Equal(new[] { current }, _viewModel.Monitors);
+            Assert.False(_viewModel.IsLoading);
+        }
+
+        [Fact]
+        public void RecalculateLayout_WhenSelectionPreserved_RestoresSelectedMonitorByHardwareId()
         {
             // Arrange
             var original = CreateMonitor("MON-1");
-            RaiseWorkspaceReady(original, CreateMonitor("MON-2", 2));
+            LoadMonitors(original, CreateMonitor("MON-2", 2));
             _viewModel.SelectMonitorCommand.Execute(original);
-            _viewModel.RecalculateLayout(800, 600);
             var rebuilt = CreateMonitor("MON-1");
 
             // Act
-            RaiseWorkspaceReady(CreateMonitor("MON-2", 2), rebuilt);
+            LoadMonitors(CreateMonitor("MON-2", 2), rebuilt);
 
             // Assert
             Assert.Same(rebuilt, _viewModel.SelectedMonitor);
@@ -132,17 +149,16 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         }
 
         [Fact]
-        public void WorkspaceReady_WhenSelectionNotPreserved_ClearsSelection()
+        public void RefreshMonitors_WhenSelectionNotPreserved_ClearsSelection()
         {
             // Arrange
             var original = CreateMonitor("MON-1");
-            RaiseWorkspaceReady(original);
+            LoadMonitors(original);
             _viewModel.SelectMonitorCommand.Execute(original);
-            _viewModel.RecalculateLayout(800, 600);
-            _viewModel.RefreshMonitors(false);
+            SetupWorkspace(CreateMonitor("MON-1"));
 
             // Act
-            RaiseWorkspaceReady(CreateMonitor("MON-1"));
+            _viewModel.RefreshMonitors(false);
 
             // Assert
             Assert.Null(_viewModel.SelectedMonitor);
@@ -150,11 +166,11 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         }
 
         [Fact]
-        public void WorkspaceReady_WhenMonitorConfigurationChanges_MarksViewModelDirty()
+        public void RecalculateLayout_WhenMonitorConfigurationChanges_MarksViewModelDirty()
         {
             // Arrange
             var monitor = CreateMonitor("MON-1");
-            RaiseWorkspaceReady(monitor);
+            LoadMonitors(monitor);
 
             // Act
             monitor.Configuration.DimLevel = 50;
@@ -188,7 +204,7 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
             // Arrange
             var first = CreateMonitor("MON-1");
             var second = CreateMonitor("MON-2", 2);
-            RaiseWorkspaceReady(first, second);
+            LoadMonitors(first, second);
 
             // Act
             _viewModel.SelectMonitorCommand.Execute(first);
@@ -206,7 +222,7 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         {
             // Arrange
             var monitor = CreateMonitor("MON-1");
-            RaiseWorkspaceReady(monitor);
+            LoadMonitors(monitor);
             _viewModel.SelectMonitorCommand.Execute(monitor);
 
             // Act
@@ -224,33 +240,36 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
 
             // Assert
             _workspaceServiceMock.Verify(x => x.BuildWorkspaceAsync(800, 600), Times.Once);
-            Assert.True(_viewModel.IsLoading);
         }
 
         [Fact]
-        public void RecalculateLayout_WithNonPositiveSize_LeavesLoadingUntouched()
+        public void RecalculateLayout_WithNonPositiveSize_RequestsNoBuild()
         {
             // Act
             _viewModel.RecalculateLayout(0, 600);
 
             // Assert
             Assert.False(_viewModel.IsLoading);
-            _workspaceServiceMock.Verify(x => x.BuildWorkspaceAsync(0, 600), Times.Once);
+            _workspaceServiceMock.Verify(
+                x => x.BuildWorkspaceAsync(It.IsAny<double>(), It.IsAny<double>()),
+                Times.Never);
         }
 
         [Fact]
-        public void RecalculateLayout_WhenWorkspaceTaskFaults_DoesNotThrow()
+        public void RecalculateLayout_WhenWorkspaceTaskFaults_DoesNotThrowAndClearsLoading()
         {
             // Arrange
             _workspaceServiceMock
                 .Setup(x => x.BuildWorkspaceAsync(It.IsAny<double>(), It.IsAny<double>()))
-                .Returns(Task.FromException(new InvalidOperationException("Simulated workspace failure.")));
+                .Returns(Task.FromException<ObservableCollection<MonitorLayoutViewModel>>(
+                    new InvalidOperationException("Simulated workspace failure.")));
 
             // Act
             var exception = Record.Exception(() => _viewModel.RecalculateLayout(800, 600));
 
             // Assert
             Assert.Null(exception);
+            Assert.False(_viewModel.IsLoading);
         }
 
         [Fact]
@@ -264,7 +283,6 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
 
             // Assert
             _workspaceServiceMock.Verify(x => x.RefreshWorkspaceAsync(800, 600), Times.Once);
-            Assert.True(_viewModel.IsLoading);
         }
 
         [Fact]
@@ -285,14 +303,13 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         {
             // Arrange
             var monitor = CreateMonitor("MON-1");
-            RaiseWorkspaceReady(monitor);
+            LoadMonitors(monitor);
             _viewModel.SelectMonitorCommand.Execute(monitor);
-            _viewModel.RecalculateLayout(800, 600);
+            var rebuilt = CreateMonitor("MON-1");
+            SetupWorkspace(rebuilt);
 
             // Act
             _viewModel.DiscardChangesCommand.Execute(null);
-            var rebuilt = CreateMonitor("MON-1");
-            RaiseWorkspaceReady(rebuilt);
 
             // Assert
             _workspaceServiceMock.Verify(x => x.RefreshWorkspaceAsync(800, 600), Times.Once);
@@ -332,7 +349,7 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         {
             // Arrange
             var monitor = CreateMonitor("MON-1");
-            RaiseWorkspaceReady(monitor);
+            LoadMonitors(monitor);
             monitor.Configuration.DimLevel = 50;
             SetupUnsavedChangesAnswer(MessageBoxResult.Yes);
 
@@ -366,7 +383,7 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         {
             // Arrange
             var monitor = CreateMonitor("MON-1");
-            RaiseWorkspaceReady(monitor);
+            LoadMonitors(monitor);
             monitor.Configuration.DimLevel = 50;
             Assert.True(_viewModel.IsDirty);
 
@@ -392,7 +409,7 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         {
             // Arrange
             var monitor = CreateMonitor("MON-1");
-            RaiseWorkspaceReady(monitor);
+            LoadMonitors(monitor);
             monitor.Configuration.IsManaged = true;
 
             // Act
@@ -409,7 +426,7 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         public void SaveAndDiscardCommands_WhenNothingIsDirty_CannotExecute()
         {
             // Arrange
-            RaiseWorkspaceReady(CreateMonitor("MON-1"));
+            LoadMonitors(CreateMonitor("MON-1"));
 
             // Act
             var canSave = _viewModel.SaveSettingsCommand.CanExecute(null);
@@ -425,7 +442,7 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         {
             // Arrange
             var monitor = CreateMonitor("MON-1");
-            RaiseWorkspaceReady(monitor);
+            LoadMonitors(monitor);
 
             // Act
             monitor.Configuration.DimLevel = 50;
@@ -436,8 +453,48 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         }
 
         /// <summary>
+        /// Makes both workspace builds return the supplied monitors as soon as they are awaited.
+        /// </summary>
+        /// <param name="monitors">The monitors each build should produce.</param>
+        private void SetupWorkspace(params MonitorLayoutViewModel[] monitors)
+        {
+            _workspaceServiceMock
+                .Setup(x => x.BuildWorkspaceAsync(It.IsAny<double>(), It.IsAny<double>()))
+                .ReturnsAsync(() => Collect(monitors));
+            _workspaceServiceMock
+                .Setup(x => x.RefreshWorkspaceAsync(It.IsAny<double>(), It.IsAny<double>()))
+                .ReturnsAsync(() => Collect(monitors));
+        }
+
+        /// <summary>
+        /// Makes the next build hang until the returned source is completed, so a second build can
+        /// be started while the first is still in flight.
+        /// </summary>
+        /// <returns>The source that completes the pending build.</returns>
+        private TaskCompletionSource<ObservableCollection<MonitorLayoutViewModel>> SetupPendingBuild()
+        {
+            var pending = new TaskCompletionSource<ObservableCollection<MonitorLayoutViewModel>>();
+            _workspaceServiceMock
+                .Setup(x => x.BuildWorkspaceAsync(It.IsAny<double>(), It.IsAny<double>()))
+                .Returns(pending.Task);
+
+            return pending;
+        }
+
+        /// <summary>
+        /// Builds the workspace with the supplied monitors and applies the result, as a resize does.
+        /// </summary>
+        /// <param name="monitors">The monitors the build should produce.</param>
+        private void LoadMonitors(params MonitorLayoutViewModel[] monitors)
+        {
+            SetupWorkspace(monitors);
+            _viewModel.RecalculateLayout(800, 600);
+        }
+
+        /// <summary>
         /// Makes the unsaved-changes prompt return the supplied answer.
         /// </summary>
+        /// <param name="answer">The answer the prompt should return.</param>
         private void SetupUnsavedChangesAnswer(MessageBoxResult answer)
         {
             _dialogServiceMock
@@ -446,8 +503,21 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         }
 
         /// <summary>
+        /// Wraps the supplied monitors in the collection type a workspace build returns.
+        /// </summary>
+        /// <param name="monitors">The monitors to wrap.</param>
+        /// <returns>A new collection holding the supplied monitors.</returns>
+        private static ObservableCollection<MonitorLayoutViewModel> Collect(params MonitorLayoutViewModel[] monitors)
+        {
+            return new ObservableCollection<MonitorLayoutViewModel>(monitors);
+        }
+
+        /// <summary>
         /// Builds a layout view model over a 1920x1080 monitor with the supplied hardware ID.
         /// </summary>
+        /// <param name="hardwareId">The hardware ID for the monitor.</param>
+        /// <param name="displayNumber">The display number for the monitor.</param>
+        /// <returns>A layout view model over the described monitor.</returns>
         private static MonitorLayoutViewModel CreateMonitor(string hardwareId, int displayNumber = 1)
         {
             var bounds = new Rect(0, 0, 1920, 1080);
@@ -460,17 +530,6 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
             };
 
             return new MonitorLayoutViewModel(monitorInfo, 1.0, bounds, 0, 0);
-        }
-
-        /// <summary>
-        /// Raises WorkspaceReady with the supplied monitors, as the workspace service does once a build finishes.
-        /// </summary>
-        private void RaiseWorkspaceReady(params MonitorLayoutViewModel[] monitors)
-        {
-            _workspaceServiceMock.Raise(
-                x => x.WorkspaceReady += null,
-                this,
-                new ObservableCollection<MonitorLayoutViewModel>(monitors));
         }
     }
 }

--- a/OLED-Sleeper/Infrastructure/Hosting/ServiceConfigurator.cs
+++ b/OLED-Sleeper/Infrastructure/Hosting/ServiceConfigurator.cs
@@ -86,6 +86,7 @@ namespace OLED_Sleeper.Infrastructure.Hosting
             services.AddSingleton<ITrayIconService, TrayIconService>();
             services.AddSingleton<IMainWindowService, MainWindowService>();
             services.AddSingleton<IDialogService, MessageBoxDialogService>();
+            services.AddSingleton<IMonitorSettingsSaveService, MonitorSettingsSaveService>();
 
             return services.BuildServiceProvider();
         }

--- a/OLED-Sleeper/UI/Services/Interfaces/IMonitorSettingsSaveService.cs
+++ b/OLED-Sleeper/UI/Services/Interfaces/IMonitorSettingsSaveService.cs
@@ -1,0 +1,18 @@
+using OLED_Sleeper.UI.ViewModels;
+
+namespace OLED_Sleeper.UI.Services.Interfaces
+{
+    /// <summary>
+    /// Validates the configured monitors and writes them to the settings file.
+    /// </summary>
+    public interface IMonitorSettingsSaveService
+    {
+        /// <summary>
+        /// Validates the supplied monitors and saves them. An invalid configuration is reported to the
+        /// user and nothing is written. Saved monitors are marked as no longer holding unsaved changes.
+        /// </summary>
+        /// <param name="monitors">The monitors whose configuration should be saved.</param>
+        /// <returns>True when the settings were written; false when validation rejected them.</returns>
+        bool TrySave(IReadOnlyList<MonitorLayoutViewModel> monitors);
+    }
+}

--- a/OLED-Sleeper/UI/Services/Interfaces/IWorkspaceService.cs
+++ b/OLED-Sleeper/UI/Services/Interfaces/IWorkspaceService.cs
@@ -10,22 +10,19 @@ namespace OLED_Sleeper.UI.Services.Interfaces
     public interface IWorkspaceService
     {
         /// <summary>
-        /// Raised when the workspace has finished building and monitor layout view models are ready.
-        /// </summary>
-        event EventHandler<ObservableCollection<MonitorLayoutViewModel>>? WorkspaceReady;
-
-        /// <summary>
         /// Builds the workspace by discovering monitors, loading settings, and constructing layout view models.
         /// </summary>
         /// <param name="containerWidth">The width of the container for layout scaling.</param>
         /// <param name="containerHeight">The height of the container for layout scaling.</param>
-        Task BuildWorkspaceAsync(double containerWidth, double containerHeight);
+        /// <returns>The layout view models for the monitors that were found.</returns>
+        Task<ObservableCollection<MonitorLayoutViewModel>> BuildWorkspaceAsync(double containerWidth, double containerHeight);
 
         /// <summary>
         /// Performs a full refresh of the workspace by re-scanning the monitor list and then rebuilding the workspace.
         /// </summary>
         /// <param name="containerWidth">The width of the container for layout scaling.</param>
         /// <param name="containerHeight">The height of the container for layout scaling.</param>
-        Task RefreshWorkspaceAsync(double containerWidth, double containerHeight);
+        /// <returns>The layout view models for the monitors that were found.</returns>
+        Task<ObservableCollection<MonitorLayoutViewModel>> RefreshWorkspaceAsync(double containerWidth, double containerHeight);
     }
 }

--- a/OLED-Sleeper/UI/Services/MonitorSettingsSaveService.cs
+++ b/OLED-Sleeper/UI/Services/MonitorSettingsSaveService.cs
@@ -1,0 +1,45 @@
+using OLED_Sleeper.Features.UserSettings.Services.Interfaces;
+using OLED_Sleeper.UI.Helpers;
+using OLED_Sleeper.UI.Services.Interfaces;
+using OLED_Sleeper.UI.ViewModels;
+
+namespace OLED_Sleeper.UI.Services
+{
+    /// <summary>
+    /// Saves monitor settings through <see cref="IMonitorSettingsFileService"/>, reporting an invalid
+    /// configuration with a modal dialog rather than writing it.
+    /// </summary>
+    public class MonitorSettingsSaveService : IMonitorSettingsSaveService
+    {
+        private readonly IMonitorSettingsFileService _settingsService;
+        private readonly IDialogService _dialogService;
+
+        public MonitorSettingsSaveService(
+            IMonitorSettingsFileService settingsService,
+            IDialogService dialogService)
+        {
+            _settingsService = settingsService;
+            _dialogService = dialogService;
+        }
+
+        /// <inheritdoc />
+        public bool TrySave(IReadOnlyList<MonitorLayoutViewModel> monitors)
+        {
+            var error = MonitorSettingsValidator.BuildValidationError(monitors);
+            if (error != null)
+            {
+                _dialogService.ShowError(error, "Monitor Configuration Error");
+                return false;
+            }
+
+            _settingsService.SaveSettings(monitors.Select(m => m.Configuration.ToSettings()).ToList());
+
+            foreach (var monitor in monitors)
+            {
+                monitor.Configuration.MarkAsSaved();
+            }
+
+            return true;
+        }
+    }
+}

--- a/OLED-Sleeper/UI/Services/WorkspaceService.cs
+++ b/OLED-Sleeper/UI/Services/WorkspaceService.cs
@@ -18,8 +18,6 @@ namespace OLED_Sleeper.UI.Services
         private readonly IMonitorSettingsFileService _settingsService;
         private readonly IMonitorLayoutService _monitorLayoutService;
 
-        public event EventHandler<ObservableCollection<MonitorLayoutViewModel>>? WorkspaceReady;
-
         public WorkspaceService(
             IMonitorInfoManager monitorManager,
             IMonitorSettingsFileService settingsService,
@@ -30,30 +28,24 @@ namespace OLED_Sleeper.UI.Services
             _monitorLayoutService = monitorLayoutService;
         }
 
-        /// <summary>
-        /// Builds the workspace asynchronously.
-        /// </summary>
-        /// <param name="containerWidth">The width of the container.</param>
-        /// <param name="containerHeight">The height of the container.</param>
-        public async Task BuildWorkspaceAsync(double containerWidth, double containerHeight)
+        /// <inheritdoc />
+        public async Task<ObservableCollection<MonitorLayoutViewModel>> BuildWorkspaceAsync(double containerWidth, double containerHeight)
         {
             var monitorInfos = await _monitorManager.GetCurrentMonitorsAsync();
 
             var savedSettings = _settingsService.LoadSettings();
             var monitorLayoutViewModels = _monitorLayoutService.CreateLayout(monitorInfos.ToList(), containerWidth, containerHeight);
             ApplySettingsToViewModels(monitorLayoutViewModels, savedSettings);
-            WorkspaceReady?.Invoke(this, monitorLayoutViewModels);
+
+            return monitorLayoutViewModels;
         }
 
-        /// <summary>
-        /// Performs a full refresh of the workspace by re-scanning the monitor list and then rebuilding the workspace.
-        /// </summary>
-        /// <param name="containerWidth">The width of the container for layout scaling.</param>
-        /// <param name="containerHeight">The height of the container for layout scaling.</param>
-        public async Task RefreshWorkspaceAsync(double containerWidth, double containerHeight)
+        /// <inheritdoc />
+        public async Task<ObservableCollection<MonitorLayoutViewModel>> RefreshWorkspaceAsync(double containerWidth, double containerHeight)
         {
             await _monitorManager.RefreshMonitorsAsync();
-            await BuildWorkspaceAsync(containerWidth, containerHeight);
+
+            return await BuildWorkspaceAsync(containerWidth, containerHeight);
         }
 
         /// <summary>

--- a/OLED-Sleeper/UI/ViewModels/MainViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MainViewModel.cs
@@ -79,9 +79,10 @@ namespace OLED_Sleeper.UI.ViewModels
         private bool _isLoading;
 
         /// <summary>
-        /// The hardware ID of the monitor to be restored upon workspace update.
+        /// Incremented for every workspace build. A build whose number is no longer current has been
+        /// superseded and its result is discarded.
         /// </summary>
-        private string? _selectedMonitorIdToRestore;
+        private int _buildGeneration;
 
         #endregion Private Fields
 
@@ -201,8 +202,6 @@ namespace OLED_Sleeper.UI.ViewModels
             ReloadMonitorsCommand = new RelayCommand(() => RefreshMonitors(false));
             SaveSettingsCommand = new AsyncRelayCommand(ExecuteSaveSettings, () => IsDirty);
             DiscardChangesCommand = new RelayCommand(ExecuteDiscardChanges, () => IsDirty);
-
-            _workspaceService.WorkspaceReady += OnWorkspaceReady;
         }
 
         #endregion Constructor
@@ -210,12 +209,12 @@ namespace OLED_Sleeper.UI.ViewModels
         #region Public Methods (for View Interaction)
 
         /// <summary>
-        /// Initiates a full refresh of the monitor list, clearing any current selection and reloading from the workspace service.
+        /// Initiates a full refresh of the monitor list, re-scanning the display set before rebuilding the layout.
         /// </summary>
+        /// <param name="preserveSelection">Whether to reselect the current monitor once the rebuild finishes.</param>
         public void RefreshMonitors(bool preserveSelection)
         {
-            UpdateMonitorsInternal(_containerWidth, _containerHeight, preserveSelection);
-            ObserveWorkspaceTask(_workspaceService.RefreshWorkspaceAsync(_containerWidth, _containerHeight));
+            ApplyWorkspace(_workspaceService.RefreshWorkspaceAsync, _containerWidth, _containerHeight, preserveSelection);
         }
 
         /// <summary>
@@ -225,22 +224,7 @@ namespace OLED_Sleeper.UI.ViewModels
         /// <param name="height">The new height of the container.</param>
         public void RecalculateLayout(double width, double height)
         {
-            UpdateMonitorsInternal(width, height, preserveSelection: true);
-            ObserveWorkspaceTask(_workspaceService.BuildWorkspaceAsync(width, height));
-        }
-
-        /// <summary>
-        /// Observes a fire-and-forget workspace task so a failure is logged instead of being lost
-        /// as an unobserved task exception.
-        /// </summary>
-        /// <param name="task">The workspace task to observe.</param>
-        private static void ObserveWorkspaceTask(Task task)
-        {
-            _ = task.ContinueWith(
-                faulted => Log.Error(faulted.Exception!.GetBaseException(), "Failed to build the monitor workspace."),
-                CancellationToken.None,
-                TaskContinuationOptions.OnlyOnFaulted,
-                TaskScheduler.Default);
+            ApplyWorkspace(_workspaceService.BuildWorkspaceAsync, width, height, preserveSelection: true);
         }
 
         /// <summary>
@@ -353,27 +337,42 @@ namespace OLED_Sleeper.UI.ViewModels
         // --- Monitor Update Helpers ---
 
         /// <summary>
-        /// The core worker method for updating the monitor list and layout.
+        /// Builds the workspace and applies the result to the UI. A build superseded by a later one
+        /// leaves the monitor list untouched. Failures are logged; nothing is thrown to the caller.
         /// </summary>
+        /// <param name="build">Produces the layout view models for the given container size.</param>
         /// <param name="width">The width of the container for layout.</param>
         /// <param name="height">The height of the container for layout.</param>
-        /// <param name="preserveSelection">Whether to preserve the current monitor selection.</param>
-        private void UpdateMonitorsInternal(double width, double height, bool preserveSelection)
+        /// <param name="preserveSelection">Whether to reselect the current monitor once the build finishes.</param>
+        private async void ApplyWorkspace(
+            Func<double, double, Task<ObservableCollection<MonitorLayoutViewModel>>> build,
+            double width,
+            double height,
+            bool preserveSelection)
         {
             if (width <= 0 || height <= 0) return;
             _containerWidth = width;
             _containerHeight = height;
 
-            _selectedMonitorIdToRestore = preserveSelection ? SelectedMonitor?.HardwareId : null;
+            var generation = ++_buildGeneration;
+            var monitorIdToRestore = preserveSelection ? SelectedMonitor?.HardwareId : null;
             IsLoading = true;
-        }
 
-        private void OnWorkspaceReady(object? sender, ObservableCollection<MonitorLayoutViewModel> newMonitorLayoutViewModels)
-        {
-            PopulateMonitors(newMonitorLayoutViewModels);
-            RestoreSelection();
-            CheckDirtyState();
-            IsLoading = false;
+            try
+            {
+                var newMonitorLayoutViewModels = await build(width, height);
+                if (generation != _buildGeneration) return;
+
+                PopulateMonitors(newMonitorLayoutViewModels);
+                RestoreSelection(monitorIdToRestore);
+                CheckDirtyState();
+                IsLoading = false;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to build the monitor workspace.");
+                if (generation == _buildGeneration) { IsLoading = false; }
+            }
         }
 
         /// <summary>
@@ -397,12 +396,13 @@ namespace OLED_Sleeper.UI.ViewModels
         }
 
         /// <summary>
-        /// Restores the monitor selection based on a hardware ID, if available.
+        /// Restores the monitor selection based on a hardware ID.
         /// </summary>
-        private void RestoreSelection()
+        /// <param name="hardwareId">The monitor to reselect, or null to clear the selection.</param>
+        private void RestoreSelection(string? hardwareId)
         {
-            SelectedMonitor = _selectedMonitorIdToRestore != null
-                ? Monitors.FirstOrDefault(m => m.HardwareId == _selectedMonitorIdToRestore)
+            SelectedMonitor = hardwareId != null
+                ? Monitors.FirstOrDefault(m => m.HardwareId == hardwareId)
                 : null;
         }
 

--- a/OLED-Sleeper/UI/ViewModels/MainViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MainViewModel.cs
@@ -1,7 +1,5 @@
-﻿using OLED_Sleeper.Features.MonitorDimming.Commands;
-using OLED_Sleeper.Features.UserSettings.Services.Interfaces;
+﻿using OLED_Sleeper.Features.UserSettings.Services.Interfaces;
 using OLED_Sleeper.Infrastructure.Runtime.Interfaces;
-using OLED_Sleeper.Messaging.Interfaces;
 using OLED_Sleeper.UI.Commands;
 using OLED_Sleeper.UI.Helpers;
 using OLED_Sleeper.UI.Services.Interfaces;
@@ -44,11 +42,6 @@ namespace OLED_Sleeper.UI.ViewModels
         /// Shows modal dialogs to the user.
         /// </summary>
         private readonly IDialogService _dialogService;
-
-        /// <summary>
-        /// Sends commands to their handlers.
-        /// </summary>
-        private readonly IMediator _mediator;
 
         /// <summary>
         /// The width of the container used for monitor layout calculations.
@@ -196,15 +189,13 @@ namespace OLED_Sleeper.UI.ViewModels
             IMonitorSettingsFileService settingsService,
             IDispatcher dispatcher,
             IMainWindowAccessor mainWindowAccessor,
-            IDialogService dialogService,
-            IMediator mediator)
+            IDialogService dialogService)
         {
             _workspaceService = workspaceService;
             _settingsService = settingsService;
             _dispatcher = dispatcher;
             _mainWindowAccessor = mainWindowAccessor;
             _dialogService = dialogService;
-            _mediator = mediator;
 
             SelectMonitorCommand = new RelayCommand(ExecuteSelectMonitor);
             ReloadMonitorsCommand = new RelayCommand(() => RefreshMonitors(false));
@@ -305,8 +296,6 @@ namespace OLED_Sleeper.UI.ViewModels
         /// </summary>
         private async Task ExecuteSaveSettings()
         {
-            _ = _mediator.SendAsync(new RestoreBrightnessOnAllMonitorsCommand());
-
             if (!ValidateSettings())
             {
                 return; // Stop if invalid

--- a/OLED-Sleeper/UI/ViewModels/MainViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MainViewModel.cs
@@ -1,7 +1,5 @@
-﻿using OLED_Sleeper.Features.UserSettings.Services.Interfaces;
-using OLED_Sleeper.Infrastructure.Runtime.Interfaces;
+﻿using OLED_Sleeper.Infrastructure.Runtime.Interfaces;
 using OLED_Sleeper.UI.Commands;
-using OLED_Sleeper.UI.Helpers;
 using OLED_Sleeper.UI.Services.Interfaces;
 using Serilog;
 using System.Collections.ObjectModel;
@@ -24,9 +22,9 @@ namespace OLED_Sleeper.UI.ViewModels
         private readonly IWorkspaceService _workspaceService;
 
         /// <summary>
-        /// Service for loading and saving monitor settings.
+        /// Validates and saves the monitor settings.
         /// </summary>
-        private readonly IMonitorSettingsFileService _settingsService;
+        private readonly IMonitorSettingsSaveService _saveService;
 
         /// <summary>
         /// Runs actions on the UI thread.
@@ -187,13 +185,13 @@ namespace OLED_Sleeper.UI.ViewModels
 
         public MainViewModel(
             IWorkspaceService workspaceService,
-            IMonitorSettingsFileService settingsService,
+            IMonitorSettingsSaveService saveService,
             IDispatcher dispatcher,
             IMainWindowAccessor mainWindowAccessor,
             IDialogService dialogService)
         {
             _workspaceService = workspaceService;
-            _settingsService = settingsService;
+            _saveService = saveService;
             _dispatcher = dispatcher;
             _mainWindowAccessor = mainWindowAccessor;
             _dialogService = dialogService;
@@ -276,16 +274,16 @@ namespace OLED_Sleeper.UI.ViewModels
         }
 
         /// <summary>
-        /// Orchestrates the three steps of the save process: validation, action, and feedback.
+        /// Saves the monitor settings and reports the outcome on the save button.
         /// </summary>
         private async Task ExecuteSaveSettings()
         {
-            if (!ValidateSettings())
+            if (!_saveService.TrySave(Monitors))
             {
                 return; // Stop if invalid
             }
 
-            PerformSaveActions();
+            CheckDirtyState();
 
             await ProvideSaveFeedbackAsync();
         }
@@ -295,34 +293,6 @@ namespace OLED_Sleeper.UI.ViewModels
         #region Private Helper Methods
 
         // --- Save Process Helpers ---
-
-        /// <summary>
-        /// Validates all monitor settings, telling the user about any that cannot be saved.
-        /// </summary>
-        /// <returns>True if all monitors are valid; otherwise, false.</returns>
-        private bool ValidateSettings()
-        {
-            var error = MonitorSettingsValidator.BuildValidationError(Monitors);
-            if (error == null) return true;
-
-            _dialogService.ShowError(error, "Monitor Configuration Error");
-            return false;
-        }
-
-        /// <summary>
-        /// Saves all monitor settings and updates the idle activity service. Marks all monitors as saved.
-        /// </summary>
-        private void PerformSaveActions()
-        {
-            var allSettings = Monitors.Select(m => m.Configuration.ToSettings()).ToList();
-            _settingsService.SaveSettings(allSettings);
-
-            foreach (var monitorVM in Monitors)
-            {
-                monitorVM.Configuration.MarkAsSaved();
-            }
-            CheckDirtyState();
-        }
 
         /// <summary>
         /// Provides user feedback after saving settings by updating the save button text temporarily.

--- a/OLED-Sleeper/UI/ViewModels/MainViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MainViewModel.cs
@@ -3,6 +3,7 @@ using OLED_Sleeper.UI.Commands;
 using OLED_Sleeper.UI.Services.Interfaces;
 using Serilog;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Windows;
 using ICommand = System.Windows.Input.ICommand;
 
@@ -357,11 +358,27 @@ namespace OLED_Sleeper.UI.ViewModels
                 return;
             }
 
+            foreach (var viewModel in Monitors)
+            {
+                viewModel.PropertyChanged -= OnMonitorPropertyChanged;
+            }
+
             Monitors.Clear();
             foreach (var viewModel in newViewModels)
             {
-                viewModel.OnMonitorDirtyStateChanged = CheckDirtyState;
+                viewModel.PropertyChanged += OnMonitorPropertyChanged;
                 Monitors.Add(viewModel);
+            }
+        }
+
+        /// <summary>
+        /// Re-evaluates the overall dirty state whenever one monitor's changes.
+        /// </summary>
+        private void OnMonitorPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(MonitorLayoutViewModel.IsDirty))
+            {
+                CheckDirtyState();
             }
         }
 

--- a/OLED-Sleeper/UI/ViewModels/MonitorConfigurationViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MonitorConfigurationViewModel.cs
@@ -17,11 +17,6 @@ namespace OLED_Sleeper.UI.ViewModels
         /// </summary>
         private readonly MonitorInfo _monitorInfo;
 
-        /// <summary>
-        /// Callback invoked when the dirty state changes.
-        /// </summary>
-        public Action? OnDirtyStateChanged { get; set; }
-
         #region Properties
 
         /// <summary>
@@ -253,7 +248,6 @@ namespace OLED_Sleeper.UI.ViewModels
                        IsActiveOnActiveWindow != _initialIsActiveOnActiveWindow;
 
             OnPropertyChanged(nameof(IsDirty));
-            OnDirtyStateChanged?.Invoke();
         }
 
         /// <summary>

--- a/OLED-Sleeper/UI/ViewModels/MonitorLayoutViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MonitorLayoutViewModel.cs
@@ -19,11 +19,6 @@ namespace OLED_Sleeper.UI.ViewModels
 
         #region Properties
         /// <summary>
-        /// Action to notify the MainViewModel that this specific monitor's dirty state has changed.
-        /// </summary>
-        public Action? OnMonitorDirtyStateChanged { get; set; }
-
-        /// <summary>
         /// The configuration ViewModel for this monitor.
         /// </summary>
         public MonitorConfigurationViewModel Configuration { get; }
@@ -38,15 +33,10 @@ namespace OLED_Sleeper.UI.ViewModels
             set { _isSelected = value; OnPropertyChanged(); }
         }
 
-        private bool _isDirty;
         /// <summary>
-        /// Gets or sets whether this monitor has unsaved changes in its configuration.
+        /// Whether this monitor has unsaved changes in its configuration.
         /// </summary>
-        public bool IsDirty
-        {
-            get => _isDirty;
-            set { _isDirty = value; OnPropertyChanged(); }
-        }
+        public bool IsDirty => Configuration.IsDirty;
 
         /// <summary>
         /// The display title for the monitor, including primary indicator if applicable.
@@ -114,14 +104,16 @@ namespace OLED_Sleeper.UI.ViewModels
 
         #region Private Methods
         /// <summary>
-        /// Subscribes to the configuration's dirty state changes and updates this ViewModel accordingly.
+        /// Re-raises the configuration's dirty state changes as this ViewModel's own.
         /// </summary>
         private void SubscribeToConfigurationDirtyState()
         {
-            Configuration.OnDirtyStateChanged = () =>
+            Configuration.PropertyChanged += (_, e) =>
             {
-                IsDirty = Configuration.IsDirty;
-                OnMonitorDirtyStateChanged?.Invoke();
+                if (e.PropertyName == nameof(MonitorConfigurationViewModel.IsDirty))
+                {
+                    OnPropertyChanged(nameof(IsDirty));
+                }
             };
         }
         #endregion


### PR DESCRIPTION
`MainViewModel` splits into workspace, save and dirty-tracking pieces, and the save-time restore runs only when the save succeeds.

* Clicking Save with an invalid idle value used to un-dim every monitor and then refuse the save. The restore now runs only through `ApplySettingsChangeCommandHandler`, after the new settings take effect.
* The restore also ran twice per save. It now runs once.
* Resizing the settings window during load started several workspace builds with nothing deciding which won, so the layout could be scaled for a stale window size and the loading overlay could clear early. A superseded build is now discarded.
* `IWorkspaceService` returns the monitors it built instead of announcing them through an event.
* The save workflow moves to `MonitorSettingsSaveService`, where validation, writing and dirty-state clearing are testable without a view model.
* Unsaved-change tracking rides `INotifyPropertyChanged` instead of three levels of assignable callbacks.
