### PR TITLE
fix: detect display changes by panel identity rather than device name

### DIFF
--- a/OLED-Sleeper.Tests/Features/MonitorBlackout/Handlers/ApplyBlackoutOverlayCommandHandlerTests.cs
+++ b/OLED-Sleeper.Tests/Features/MonitorBlackout/Handlers/ApplyBlackoutOverlayCommandHandlerTests.cs
@@ -37,7 +37,7 @@ namespace OLED_Sleeper.Tests.Features.MonitorBlackout.Handlers
 
             var monitors = new List<MonitorInfo>
             {
-                new MonitorInfo { HardwareId = hardwareId, IsDdcCiSupported = true, Bounds = new Rect(0, 0, 1920, 1080) }
+                new MonitorInfo { HardwareId = hardwareId, Capabilities = new DdcCiCapabilities(true, 100), Bounds = new Rect(0, 0, 1920, 1080) }
             };
 
             SetupMonitors(monitors);
@@ -67,7 +67,7 @@ namespace OLED_Sleeper.Tests.Features.MonitorBlackout.Handlers
 
             var monitors = new List<MonitorInfo>
             {
-                new MonitorInfo { HardwareId = hardwareId, IsDdcCiSupported = false, Bounds = new Rect(0, 0, 1920, 1080) }
+                new MonitorInfo { HardwareId = hardwareId, Capabilities = new DdcCiCapabilities(false, 0), Bounds = new Rect(0, 0, 1920, 1080) }
             };
 
             SetupMonitors(monitors);
@@ -112,7 +112,7 @@ namespace OLED_Sleeper.Tests.Features.MonitorBlackout.Handlers
 
             var monitors = new List<MonitorInfo>
             {
-                new MonitorInfo { HardwareId = hardwareId, IsDdcCiSupported = false, Bounds = new Rect(0, 0, 1920, 1080) }
+                new MonitorInfo { HardwareId = hardwareId, Capabilities = new DdcCiCapabilities(false, 0), Bounds = new Rect(0, 0, 1920, 1080) }
             };
 
             SetupMonitors(monitors);

--- a/OLED-Sleeper.Tests/Features/MonitorDimming/Services/MonitorDimmingServiceTests.cs
+++ b/OLED-Sleeper.Tests/Features/MonitorDimming/Services/MonitorDimmingServiceTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+﻿using Moq;
 using OLED_Sleeper.Features.MonitorDimming.Services;
 using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
 using OLED_Sleeper.Features.MonitorInformation.Models;
@@ -333,8 +333,7 @@ namespace OLED_Sleeper.Tests.Features.MonitorDimming.Services
             {
                 HardwareId = hardwareId,
                 DeviceName = deviceName,
-                MaxBrightness = maxBrightness,
-                IsDdcCiSupported = true
+                Capabilities = new DdcCiCapabilities(true, maxBrightness)
             };
         }
 

--- a/OLED-Sleeper.Tests/Features/MonitorState/Helpers/DisplaySetComparerTests.cs
+++ b/OLED-Sleeper.Tests/Features/MonitorState/Helpers/DisplaySetComparerTests.cs
@@ -1,0 +1,195 @@
+﻿using OLED_Sleeper.Features.MonitorInformation.Models;
+using OLED_Sleeper.Features.MonitorState.Helpers;
+using System.Windows;
+
+namespace OLED_Sleeper.Tests.Features.MonitorState.Helpers
+{
+    public class DisplaySetComparerTests
+    {
+        private const string PanelA = "MONITOR\\GSM5C7C\\{4d36e96e-e325-11ce-bfc1-08002be10318}\\0002";
+        private const string PanelB = "MONITOR\\ACR074D\\{4d36e96e-e325-11ce-bfc1-08002be10318}\\0003";
+
+        [Fact]
+        public void AreEquivalent_WhenBothReadingsMatch_ReturnsTrue()
+        {
+            // Arrange
+            var first = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0), Monitor("\\\\.\\DISPLAY2", PanelB, 2560) };
+            var second = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0), Monitor("\\\\.\\DISPLAY2", PanelB, 2560) };
+
+            // Act
+            var equivalent = DisplaySetComparer.AreEquivalent(first, second);
+
+            // Assert
+            Assert.True(equivalent);
+        }
+
+        [Fact]
+        public void AreEquivalent_WhenTheReadingsAreInDifferentOrder_ReturnsTrue()
+        {
+            // Arrange
+            var first = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0), Monitor("\\\\.\\DISPLAY2", PanelB, 2560) };
+            var second = new[] { Monitor("\\\\.\\DISPLAY2", PanelB, 2560), Monitor("\\\\.\\DISPLAY1", PanelA, 0) };
+
+            // Act
+            var equivalent = DisplaySetComparer.AreEquivalent(first, second);
+
+            // Assert
+            Assert.True(equivalent);
+        }
+
+        [Fact]
+        public void AreEquivalent_WhenAReadingIsNull_ReturnsFalse()
+        {
+            // Arrange
+            var reading = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0) };
+
+            // Act & Assert
+            Assert.False(DisplaySetComparer.AreEquivalent(null, reading));
+            Assert.False(DisplaySetComparer.AreEquivalent(reading, null));
+        }
+
+        [Fact]
+        public void AreEquivalent_WhenAMonitorWasDisconnected_ReturnsFalse()
+        {
+            // Arrange
+            var first = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0), Monitor("\\\\.\\DISPLAY2", PanelB, 2560) };
+            var second = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0) };
+
+            // Act
+            var equivalent = DisplaySetComparer.AreEquivalent(first, second);
+
+            // Assert
+            Assert.False(equivalent);
+        }
+
+        [Fact]
+        public void AreEquivalent_WhenWindowsMovedAPanelToAnotherDeviceName_ReturnsFalse()
+        {
+            // Arrange
+            var first = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0), Monitor("\\\\.\\DISPLAY2", PanelB, 2560) };
+            var second = new[] { Monitor("\\\\.\\DISPLAY2", PanelA, 0), Monitor("\\\\.\\DISPLAY1", PanelB, 2560) };
+
+            // Act
+            var equivalent = DisplaySetComparer.AreEquivalent(first, second);
+
+            // Assert
+            Assert.False(equivalent);
+        }
+
+        [Fact]
+        public void AreEquivalent_WhenAnotherPanelTookOverTheDeviceName_ReturnsFalse()
+        {
+            // Arrange
+            var first = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0) };
+            var second = new[] { Monitor("\\\\.\\DISPLAY1", PanelB, 0) };
+
+            // Act
+            var equivalent = DisplaySetComparer.AreEquivalent(first, second);
+
+            // Assert
+            Assert.False(equivalent);
+        }
+
+        [Fact]
+        public void AreEquivalent_WhenThePrimaryDisplayMoved_ReturnsFalse()
+        {
+            // Arrange
+            var first = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0, isPrimary: true) };
+            var second = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0, isPrimary: false) };
+
+            // Act
+            var equivalent = DisplaySetComparer.AreEquivalent(first, second);
+
+            // Assert
+            Assert.False(equivalent);
+        }
+
+        [Fact]
+        public void AreEquivalent_WhenAMonitorMoved_ReturnsFalse()
+        {
+            // Arrange
+            var first = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0) };
+            var second = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, -2560) };
+
+            // Act
+            var equivalent = DisplaySetComparer.AreEquivalent(first, second);
+
+            // Assert
+            Assert.False(equivalent);
+        }
+
+        [Fact]
+        public void AreEquivalent_WhenTheScalingChanged_ReturnsFalse()
+        {
+            // Arrange
+            var first = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0, dpi: 96) };
+            var second = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0, dpi: 120) };
+
+            // Act
+            var equivalent = DisplaySetComparer.AreEquivalent(first, second);
+
+            // Assert
+            Assert.False(equivalent);
+        }
+
+        [Fact]
+        public void AreEquivalent_WhenAHardwareIdMomentarilyDidNotResolve_ReturnsTrue()
+        {
+            // Arrange
+            var first = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0), Monitor("\\\\.\\DISPLAY2", PanelB, 2560) };
+            var second = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0), Monitor("\\\\.\\DISPLAY2", string.Empty, 2560) };
+
+            // Act
+            var equivalent = DisplaySetComparer.AreEquivalent(first, second);
+
+            // Assert
+            Assert.True(equivalent);
+        }
+
+        [Fact]
+        public void AreEquivalent_WhenAHardwareIdResolvedAgain_ReturnsTrue()
+        {
+            // Arrange
+            var first = new[] { Monitor("\\\\.\\DISPLAY1", string.Empty, 0) };
+            var second = new[] { Monitor("\\\\.\\DISPLAY1", PanelA, 0) };
+
+            // Act
+            var equivalent = DisplaySetComparer.AreEquivalent(first, second);
+
+            // Assert
+            Assert.True(equivalent);
+        }
+
+        [Fact]
+        public void AreEquivalent_WhenAnUnresolvedMonitorMoved_ReturnsFalse()
+        {
+            // Arrange
+            var first = new[] { Monitor("\\\\.\\DISPLAY1", string.Empty, 0) };
+            var second = new[] { Monitor("\\\\.\\DISPLAY1", string.Empty, -2560) };
+
+            // Act
+            var equivalent = DisplaySetComparer.AreEquivalent(first, second);
+
+            // Assert
+            Assert.False(equivalent);
+        }
+
+        private static MonitorInfo Monitor(
+            string deviceName,
+            string hardwareId,
+            double left,
+            bool isPrimary = false,
+            uint dpi = 96)
+        {
+            return new MonitorInfo
+            {
+                DeviceName = deviceName,
+                HardwareId = hardwareId,
+                Bounds = new Rect(left, 0, 2560, 1440),
+                IsPrimary = isPrimary,
+                Dpi = dpi,
+                DisplayNumber = int.Parse(deviceName[^1..])
+            };
+        }
+    }
+}

--- a/OLED-Sleeper/Features/MonitorBlackout/Handlers/ApplyBlackoutOverlayCommandHandler.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Handlers/ApplyBlackoutOverlayCommandHandler.cs
@@ -52,7 +52,7 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Handlers
 
                 var showOverlayTask = _monitorBlackoutService.ShowBlackoutOverlayAsync(monitorInfo.HardwareId, monitorInfo.Bounds);
 
-                if (monitorInfo.IsDdcCiSupported)
+                if (monitorInfo.Capabilities?.IsSupported == true)
                 {
                     Log.Information("Monitor {HardwareId} supports DDC/CI. Setting brightness to 0 for blackout.", monitorInfo.HardwareId);
                     var dimTask = _monitorDimmingService.DimMonitorAsync(monitorInfo.HardwareId, 0);

--- a/OLED-Sleeper/Features/MonitorDimming/Services/MonitorDimmingService.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/MonitorDimmingService.cs
@@ -1,4 +1,4 @@
-using OLED_Sleeper.Features.MonitorDimming.Helpers;
+﻿using OLED_Sleeper.Features.MonitorDimming.Helpers;
 using OLED_Sleeper.Features.MonitorDimming.Services.Interfaces;
 using OLED_Sleeper.Features.MonitorInformation.Services.Interfaces;
 using Serilog;
@@ -117,7 +117,7 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
         private async Task<uint> ScaleToMonitorRangeAsync(string hardwareId, int dimLevel)
         {
             var monitors = await _monitorManager.GetCurrentMonitorsAsync();
-            var maxBrightness = monitors.FirstOrDefault(m => m.HardwareId == hardwareId)?.MaxBrightness ?? 0;
+            var maxBrightness = monitors.FirstOrDefault(m => m.HardwareId == hardwareId)?.Capabilities?.MaxBrightness ?? 0;
 
             var targetBrightness = BrightnessScale.ToRawBrightness(dimLevel, maxBrightness);
             if (targetBrightness != dimLevel)

--- a/OLED-Sleeper/Features/MonitorInformation/Models/MonitorInfo.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Models/MonitorInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows;
+using System.Windows;
 
 namespace OLED_Sleeper.Features.MonitorInformation.Models
 {
@@ -9,13 +9,14 @@ namespace OLED_Sleeper.Features.MonitorInformation.Models
     public class MonitorInfo
     {
         /// <summary>
-        /// Gets or sets the device name (e.g., \\.\DISPLAY1).
+        /// Gets or sets the device name (e.g., \\.\DISPLAY1). Windows reassigns these between panels when
+        /// the display set changes.
         /// </summary>
         public string DeviceName { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the unique hardware ID for the monitor.
-        /// Empty until the monitor is enriched; an enriched list never contains an empty one.
+        /// Empty when no attached display device matched.
         /// </summary>
         public string HardwareId { get; set; } = string.Empty;
 
@@ -40,14 +41,9 @@ namespace OLED_Sleeper.Features.MonitorInformation.Models
         public int DisplayNumber { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether DDC/CI is supported by this monitor.
+        /// Gets or sets what a DDC/CI probe of this monitor reported.
+        /// Null until the monitor has been probed.
         /// </summary>
-        public bool IsDdcCiSupported { get; set; }
-
-        /// <summary>
-        /// Gets or sets the highest value the monitor accepts for the brightness VCP code.
-        /// Zero when the monitor has not been probed or reported no range.
-        /// </summary>
-        public uint MaxBrightness { get; set; }
+        public DdcCiCapabilities? Capabilities { get; set; }
     }
 }

--- a/OLED-Sleeper/Features/MonitorInformation/Services/Interfaces/IMonitorInfoManager.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/Interfaces/IMonitorInfoManager.cs
@@ -21,13 +21,14 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services.Interfaces
         Task<IReadOnlyList<MonitorInfo>> RefreshMonitorsAsync();
 
         /// <summary>
-        /// Gets the latest, up-to-date list of monitors from the system (basic info only, no enrichment).
+        /// Gets the latest, up-to-date list of monitors from the system (basic info only, no DDC/CI probing).
         /// </summary>
-        /// <returns>A list of <see cref="MonitorInfo"/> objects representing the latest monitors.</returns>
+        /// <returns>A list of <see cref="MonitorInfo"/> objects representing the latest monitors, including
+        /// any whose hardware ID did not resolve.</returns>
         List<MonitorInfo> GetLatestMonitorsBasicInfo();
 
         /// <summary>
-        /// Enriches a list of MonitorInfo objects with DDC/CI support and hardware ID.
+        /// Enriches a list of MonitorInfo objects with their DDC/CI capabilities.
         /// </summary>
         /// <param name="monitors">The list of monitors to enrich.</param>
         void EnrichMonitorInfoList(List<MonitorInfo> monitors);

--- a/OLED-Sleeper/Features/MonitorInformation/Services/Interfaces/IMonitorInfoProvider.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/Interfaces/IMonitorInfoProvider.cs
@@ -1,16 +1,19 @@
-using OLED_Sleeper.Features.MonitorInformation.Models;
+﻿using OLED_Sleeper.Features.MonitorInformation.Models;
 
 namespace OLED_Sleeper.Features.MonitorInformation.Services.Interfaces
 {
     /// <summary>
-    /// Defines the contract for providing basic monitor information and DDC/CI support.
+    /// Defines the contract for reading the attached monitors and probing them over DDC/CI.
+    /// Reading and probing are separate calls: the first is cheap, the second is a bus round trip.
     /// </summary>
     public interface IMonitorInfoProvider
     {
         /// <summary>
-        /// Enumerates all monitors connected to the system and returns their basic information (no enrichment).
+        /// Enumerates the attached monitors, resolving names, geometry and hardware IDs in one pass.
+        /// No DDC/CI probing is performed.
         /// </summary>
-        /// <returns>A list of <see cref="MonitorInfo"/> objects representing each monitor (basic info only).</returns>
+        /// <returns>One entry per attached monitor, with no capabilities. A monitor whose hardware ID
+        /// could not be resolved is still returned, with <see cref="MonitorInfo.HardwareId"/> empty.</returns>
         List<MonitorInfo> GetAllMonitorsBasicInfo();
 
         /// <summary>
@@ -19,12 +22,5 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services.Interfaces
         /// <param name="monitor">The monitor to probe.</param>
         /// <returns>What the probe reported. Both fields are unset when the monitor did not answer.</returns>
         DdcCiCapabilities GetDdcCiCapabilities(MonitorInfo monitor);
-
-        /// <summary>
-        /// Returns the hardware ID for the given monitor.
-        /// </summary>
-        /// <param name="monitor">The monitor to get the hardware ID for.</param>
-        /// <returns>The hardware ID string, or null when no attached display device matched the monitor.</returns>
-        string? GetHardwareId(MonitorInfo monitor);
     }
 }

--- a/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoManager.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoManager.cs
@@ -5,7 +5,7 @@ using Serilog;
 namespace OLED_Sleeper.Features.MonitorInformation.Services
 {
     /// <summary>
-    /// Manages monitor information, including caching and enrichment with DDC/CI support and hardware IDs.
+    /// Manages monitor information, including caching and enrichment with DDC/CI capabilities.
     /// </summary>
     public class MonitorInfoManager : IMonitorInfoManager
     {
@@ -65,7 +65,7 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
 
         /// <inheritdoc />
         /// <remarks>
-        /// A monitor whose hardware ID cannot be resolved is removed from the list.
+        /// A monitor whose hardware ID was not resolved is removed from the list.
         /// </remarks>
         public void EnrichMonitorInfoList(List<MonitorInfo>? monitors)
         {
@@ -74,12 +74,7 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
             {
                 var monitor = monitors[index];
 
-                var capabilities = _monitorInfoProvider.GetDdcCiCapabilities(monitor);
-                monitor.IsDdcCiSupported = capabilities.IsSupported;
-                monitor.MaxBrightness = capabilities.MaxBrightness;
-
-                var hardwareId = _monitorInfoProvider.GetHardwareId(monitor);
-                if (string.IsNullOrEmpty(hardwareId))
+                if (string.IsNullOrEmpty(monitor.HardwareId))
                 {
                     Log.Warning("No hardware ID resolved for {DeviceName}. The monitor is dropped and will not be managed.",
                         monitor.DeviceName);
@@ -87,7 +82,7 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
                     continue;
                 }
 
-                monitor.HardwareId = hardwareId;
+                monitor.Capabilities = _monitorInfoProvider.GetDdcCiCapabilities(monitor);
             }
         }
 

--- a/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoProvider.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoProvider.cs
@@ -9,17 +9,15 @@ using System.Windows;
 namespace OLED_Sleeper.Features.MonitorInformation.Services
 {
     /// <summary>
-    /// Provides monitor enumeration and hardware ID / DDC/CI support services.
+    /// Reads the attached monitors through the Win32 display APIs and probes them over DDC/CI.
     /// Implements <see cref="IMonitorInfoProvider"/> for dependency injection.
     /// </summary>
     public class MonitorInfoProvider : IMonitorInfoProvider
     {
-        /// <summary>
-        /// Enumerates all monitors connected to the system and returns their basic information (no enrichment).
-        /// </summary>
-        /// <returns>A list of <see cref="MonitorInfo"/> objects representing each monitor (basic info only).</returns>
+        /// <inheritdoc />
         public List<MonitorInfo> GetAllMonitorsBasicInfo()
         {
+            var hardwareIdsByDeviceName = MapDeviceNamesToHardwareIds();
             var monitors = new List<MonitorInfo>();
 
             NativeMethods.MonitorEnumProc callback = (IntPtr hMonitor, IntPtr hdcMonitor, ref NativeMethods.Rect lprcMonitor, IntPtr dwData) =>
@@ -28,15 +26,23 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
                 if (NativeMethods.GetMonitorInfo(hMonitor, ref mi))
                 {
                     NativeMethods.GetDpiForMonitor(hMonitor, NativeMethods.MonitorDpiType.MDT_EFFECTIVE_DPI, out uint dpiX, out _);
+                    hardwareIdsByDeviceName.TryGetValue(mi.szDevice, out var hardwareId);
+
+                    if (string.IsNullOrEmpty(hardwareId))
+                    {
+                        Log.Debug("No hardware ID resolved for {DeviceName}.", mi.szDevice);
+                    }
+
                     monitors.Add(new MonitorInfo
                     {
                         DeviceName = mi.szDevice,
+                        HardwareId = hardwareId ?? string.Empty,
                         Bounds = new Rect(
                             mi.rcMonitor.left,
                             mi.rcMonitor.top,
                             mi.rcMonitor.right - mi.rcMonitor.left,
                             mi.rcMonitor.bottom - mi.rcMonitor.top),
-                        IsPrimary = (mi.dwFlags & 1) == 1,
+                        IsPrimary = (mi.dwFlags & NativeMethods.MONITORINFOF_PRIMARY) == NativeMethods.MONITORINFOF_PRIMARY,
                         Dpi = dpiX,
                         DisplayNumber = ParseDisplayNumber(mi.szDevice)
                     });
@@ -48,10 +54,7 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
             return monitors;
         }
 
-        /// <summary>
-        /// Probes the given monitor over DDC/CI for its support and its brightness range.
-        /// Both are read from a single physical monitor handle.
-        /// </summary>
+        /// <inheritdoc />
         public DdcCiCapabilities GetDdcCiCapabilities(MonitorInfo monitor)
         {
             bool isSupported = false;
@@ -90,29 +93,28 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
         }
 
         /// <summary>
-        /// Returns the hardware ID for the given monitor, or null when no attached display device matched it.
+        /// Walks the attached display adapters once and maps each adapter's device name to the hardware ID
+        /// of the monitor on it.
         /// </summary>
-        public string? GetHardwareId(MonitorInfo monitor)
+        /// <returns>The hardware ID for each adapter that reported one.</returns>
+        private static Dictionary<string, string> MapDeviceNamesToHardwareIds()
         {
-            string deviceName = monitor.DeviceName;
-            string? hardwareId = null;
-            var displayDevice = new NativeMethods.DISPLAY_DEVICE { cb = Marshal.SizeOf(typeof(NativeMethods.DISPLAY_DEVICE)) };
-            for (uint adapterIndex = 0; NativeMethods.EnumDisplayDevices(null, adapterIndex, ref displayDevice, 0); adapterIndex++)
+            var hardwareIdsByDeviceName = new Dictionary<string, string>();
+            var adapter = new NativeMethods.DISPLAY_DEVICE { cb = Marshal.SizeOf(typeof(NativeMethods.DISPLAY_DEVICE)) };
+
+            for (uint adapterIndex = 0; NativeMethods.EnumDisplayDevices(null, adapterIndex, ref adapter, 0); adapterIndex++)
             {
-                if ((displayDevice.StateFlags & 1) == 0) continue;
+                if ((adapter.StateFlags & NativeMethods.DISPLAY_DEVICE_ATTACHED_TO_DESKTOP) == 0) continue;
+
                 var monitorDevice = new NativeMethods.DISPLAY_DEVICE { cb = Marshal.SizeOf(typeof(NativeMethods.DISPLAY_DEVICE)) };
-                for (uint monitorIndex = 0; NativeMethods.EnumDisplayDevices(displayDevice.DeviceName, monitorIndex, ref monitorDevice, 0); monitorIndex++)
-                {
-                    if (deviceName == displayDevice.DeviceName)
-                    {
-                        hardwareId = monitorDevice.DeviceID;
-                        Log.Debug("HWID for monitor {DeviceName}: {HWID}", deviceName, hardwareId);
-                        break;
-                    }
-                }
-                if (hardwareId != null) break;
+                if (!NativeMethods.EnumDisplayDevices(adapter.DeviceName, 0, ref monitorDevice, 0)) continue;
+                if (string.IsNullOrEmpty(monitorDevice.DeviceID)) continue;
+
+                hardwareIdsByDeviceName[adapter.DeviceName] = monitorDevice.DeviceID;
+                Log.Debug("HWID for monitor {DeviceName}: {HWID}", adapter.DeviceName, monitorDevice.DeviceID);
             }
-            return hardwareId;
+
+            return hardwareIdsByDeviceName;
         }
 
         /// <summary>

--- a/OLED-Sleeper/Features/MonitorState/Helpers/DisplaySetComparer.cs
+++ b/OLED-Sleeper/Features/MonitorState/Helpers/DisplaySetComparer.cs
@@ -1,0 +1,102 @@
+using OLED_Sleeper.Features.MonitorInformation.Models;
+
+namespace OLED_Sleeper.Features.MonitorState.Helpers
+{
+    /// <summary>
+    /// Decides whether two readings of the display set describe the same arrangement.
+    /// Capabilities take no part in the comparison.
+    /// </summary>
+    public static class DisplaySetComparer
+    {
+        /// <summary>
+        /// Compares two readings panel by panel.
+        /// <para>
+        /// Panels are paired by hardware ID, so a reading where Windows has moved a panel to a different
+        /// device name still lines that panel up with itself and reports the move as a change. A panel whose
+        /// hardware ID resolved in only one of the two readings is paired by device name instead, so a
+        /// momentary resolution failure does not read as a display being unplugged.
+        /// </para>
+        /// </summary>
+        /// <param name="first">The first reading.</param>
+        /// <param name="second">The second reading.</param>
+        /// <returns>True when both readings describe the same panels in the same places; otherwise, false.
+        /// A null reading never compares equal.</returns>
+        public static bool AreEquivalent(IReadOnlyList<MonitorInfo>? first, IReadOnlyList<MonitorInfo>? second)
+        {
+            if (first == null || second == null) return false;
+            if (first.Count != second.Count) return false;
+
+            var unpaired = new List<MonitorInfo>(second);
+            var deferred = new List<MonitorInfo>();
+
+            foreach (var monitor in first)
+            {
+                var index = FindByHardwareId(unpaired, monitor);
+                if (index < 0)
+                {
+                    deferred.Add(monitor);
+                    continue;
+                }
+
+                if (!HasSamePlacement(monitor, unpaired[index])) return false;
+                unpaired.RemoveAt(index);
+            }
+
+            foreach (var monitor in deferred)
+            {
+                var index = FindByDeviceName(unpaired, monitor);
+                if (index < 0) return false;
+
+                if (!HasSamePlacement(monitor, unpaired[index])) return false;
+                unpaired.RemoveAt(index);
+            }
+
+            return unpaired.Count == 0;
+        }
+
+        /// <summary>
+        /// Finds the reading of the same panel, matching on hardware ID.
+        /// </summary>
+        /// <param name="candidates">The entries not yet paired.</param>
+        /// <param name="monitor">The entry to pair.</param>
+        /// <returns>The index of the match, or -1 when there is none.</returns>
+        private static int FindByHardwareId(List<MonitorInfo> candidates, MonitorInfo monitor)
+        {
+            if (monitor.HardwareId.Length == 0) return -1;
+
+            return candidates.FindIndex(candidate => candidate.HardwareId == monitor.HardwareId);
+        }
+
+        /// <summary>
+        /// Finds the reading of the same panel by device name, for a panel whose hardware ID resolved in
+        /// only one of the two readings. Two entries that both resolved to different hardware IDs are never
+        /// paired this way — under one device name those are two different panels.
+        /// </summary>
+        /// <param name="candidates">The entries not yet paired.</param>
+        /// <param name="monitor">The entry to pair.</param>
+        /// <returns>The index of the match, or -1 when there is none.</returns>
+        private static int FindByDeviceName(List<MonitorInfo> candidates, MonitorInfo monitor)
+        {
+            return candidates.FindIndex(candidate =>
+                candidate.DeviceName == monitor.DeviceName
+                && (monitor.HardwareId.Length == 0 || candidate.HardwareId.Length == 0));
+        }
+
+        /// <summary>
+        /// Compares where and how a paired panel is presented. The device name is part of this: the app
+        /// addresses monitors over DDC/CI by name, so a panel that keeps its hardware ID but moves to a
+        /// different name has changed in a way that must be acted on.
+        /// </summary>
+        /// <param name="first">The first reading of the panel.</param>
+        /// <param name="second">The second reading of the panel.</param>
+        /// <returns>True when both describe the same name, rectangle, scaling and role; otherwise, false.</returns>
+        private static bool HasSamePlacement(MonitorInfo first, MonitorInfo second)
+        {
+            return first.DeviceName == second.DeviceName
+                && first.Bounds == second.Bounds
+                && first.Dpi == second.Dpi
+                && first.IsPrimary == second.IsPrimary
+                && first.DisplayNumber == second.DisplayNumber;
+        }
+    }
+}

--- a/OLED-Sleeper/Features/MonitorState/Services/MonitorStateWatcher.cs
+++ b/OLED-Sleeper/Features/MonitorState/Services/MonitorStateWatcher.cs
@@ -1,6 +1,7 @@
-using OLED_Sleeper.Features.MonitorInformation.Models;
+﻿using OLED_Sleeper.Features.MonitorInformation.Models;
 using OLED_Sleeper.Features.MonitorInformation.Services.Interfaces;
 using OLED_Sleeper.Features.MonitorState.Commands;
+using OLED_Sleeper.Features.MonitorState.Helpers;
 using OLED_Sleeper.Features.MonitorState.Services.Interfaces;
 using OLED_Sleeper.Messaging.Interfaces;
 using Serilog;
@@ -21,8 +22,15 @@ namespace OLED_Sleeper.Features.MonitorState.Services
         private readonly IMediator _mediator;
         private readonly Timer _pollTimer;
         private readonly object _lock = new();
+
+        /// <summary>The last probed list, carried into the next synchronization as its old monitors.</summary>
         private IReadOnlyList<MonitorInfo> _lastKnownMonitors = Array.Empty<MonitorInfo>();
-        private IReadOnlyList<MonitorInfo>? _pendingMonitors;
+
+        /// <summary>The reading every poll is compared against. Always a whole reading, never the probed
+        /// subset, which leaves out monitors whose hardware ID did not resolve.</summary>
+        private IReadOnlyList<MonitorInfo> _lastReading = Array.Empty<MonitorInfo>();
+
+        private IReadOnlyList<MonitorInfo>? _pendingReading;
         private int _pollInProgress;
         private volatile bool _isStopped;
 
@@ -95,9 +103,12 @@ namespace OLED_Sleeper.Features.MonitorState.Services
 
                 if (_isStopped) return;
 
+                var reading = _monitorInfoManager.GetLatestMonitorsBasicInfo();
+
                 lock (_lock)
                 {
                     _lastKnownMonitors = monitors;
+                    _lastReading = reading;
                 }
 
                 await _mediator.SendAsync(new SynchronizeMonitorStateCommand([], monitors));
@@ -134,23 +145,23 @@ namespace OLED_Sleeper.Features.MonitorState.Services
         /// <summary>
         /// Reads the current display set, and when a change is confirmed, refreshes the shared monitor cache
         /// and dispatches a synchronization command carrying the freshly enriched list.
-        /// <see cref="_lock"/> covers only the comparison and the swap of <see cref="_lastKnownMonitors"/>;
+        /// <see cref="_lock"/> covers only the comparison and the swap of the last known state;
         /// neither the refresh nor the mediator dispatch runs under it.
         /// </summary>
         private async Task PollForChangesAsync()
         {
             try
             {
-                var currentMonitors = _monitorInfoManager.GetLatestMonitorsBasicInfo();
+                var currentReading = _monitorInfoManager.GetLatestMonitorsBasicInfo();
 
-                if (currentMonitors.Count == 0)
+                if (currentReading.Count == 0)
                 {
                     Log.Debug("Monitor poll returned an empty display set. Treating it as transient.");
                     ClearPendingChange();
                     return;
                 }
 
-                if (!IsChangeConfirmed(currentMonitors)) return;
+                if (!IsChangeConfirmed(currentReading)) return;
 
                 var refreshedMonitors = await _monitorInfoManager.RefreshMonitorsAsync();
 
@@ -171,6 +182,7 @@ namespace OLED_Sleeper.Features.MonitorState.Services
                 {
                     oldMonitors = _lastKnownMonitors;
                     _lastKnownMonitors = refreshedMonitors;
+                    _lastReading = currentReading;
                 }
 
                 await DispatchSynchronizationAsync(oldMonitors, refreshedMonitors);
@@ -186,28 +198,28 @@ namespace OLED_Sleeper.Features.MonitorState.Services
         }
 
         /// <summary>
-        /// Determines whether a detected difference from the last known monitor list is stable enough to act on.
+        /// Determines whether a detected difference from the last known reading is stable enough to act on.
         /// </summary>
-        /// <param name="currentMonitors">The display set read by this poll.</param>
+        /// <param name="currentReading">The display set read by this poll.</param>
         /// <returns>True if the same change has now been observed twice in a row; otherwise, false.</returns>
-        private bool IsChangeConfirmed(IReadOnlyList<MonitorInfo> currentMonitors)
+        private bool IsChangeConfirmed(IReadOnlyList<MonitorInfo> currentReading)
         {
             lock (_lock)
             {
-                if (AreMonitorListsEqual(_lastKnownMonitors, currentMonitors))
+                if (DisplaySetComparer.AreEquivalent(_lastReading, currentReading))
                 {
-                    _pendingMonitors = null;
+                    _pendingReading = null;
                     return false;
                 }
 
-                if (!AreMonitorListsEqual(_pendingMonitors, currentMonitors))
+                if (!DisplaySetComparer.AreEquivalent(_pendingReading, currentReading))
                 {
                     Log.Debug("Display change observed. Waiting for a second matching reading before acting.");
-                    _pendingMonitors = currentMonitors;
+                    _pendingReading = currentReading;
                     return false;
                 }
 
-                _pendingMonitors = null;
+                _pendingReading = null;
                 return true;
             }
         }
@@ -219,7 +231,7 @@ namespace OLED_Sleeper.Features.MonitorState.Services
         {
             lock (_lock)
             {
-                _pendingMonitors = null;
+                _pendingReading = null;
             }
         }
 
@@ -238,53 +250,6 @@ namespace OLED_Sleeper.Features.MonitorState.Services
             {
                 Log.Error(ex, "Failed to synchronize monitor state after a display change.");
             }
-        }
-
-        /// <summary>
-        /// Compares two monitor lists for equality by device name and per-monitor geometry.
-        /// </summary>
-        /// <param name="a">First monitor list.</param>
-        /// <param name="b">Second monitor list.</param>
-        /// <returns>True if the lists describe the same displays with the same geometry; otherwise, false.</returns>
-        /// <remarks>
-        /// <see cref="MonitorInfo.HardwareId"/> is not compared — the lists come from
-        /// <c>GetLatestMonitorsBasicInfo</c>, which does not populate it. A port swap that puts a different
-        /// panel under the same device name with identical geometry is therefore not detected.
-        /// </remarks>
-        private static bool AreMonitorListsEqual(IReadOnlyList<MonitorInfo>? a, IReadOnlyList<MonitorInfo>? b)
-        {
-            if (a == null || b == null) return false;
-            if (a.Count != b.Count) return false;
-
-            var byDeviceName = new Dictionary<string, MonitorInfo>(a.Count);
-            foreach (var monitor in a)
-            {
-                if (monitor.DeviceName == null) return false;
-                if (!byDeviceName.TryAdd(monitor.DeviceName, monitor)) return false;
-            }
-
-            foreach (var monitor in b)
-            {
-                if (monitor.DeviceName == null) return false;
-                if (!byDeviceName.TryGetValue(monitor.DeviceName, out var counterpart)) return false;
-                if (!HasSameGeometry(monitor, counterpart)) return false;
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Compares the geometry-bearing fields of two records describing the same device name.
-        /// </summary>
-        /// <param name="a">First monitor record.</param>
-        /// <param name="b">Second monitor record.</param>
-        /// <returns>True if both describe the same rectangle, scaling and role; otherwise, false.</returns>
-        private static bool HasSameGeometry(MonitorInfo a, MonitorInfo b)
-        {
-            return a.Bounds == b.Bounds
-                && a.Dpi == b.Dpi
-                && a.IsPrimary == b.IsPrimary
-                && a.DisplayNumber == b.DisplayNumber;
         }
 
         #endregion Private Methods

--- a/OLED-Sleeper/Features/UserSettings/Handlers/ApplySettingsChangeCommandHandler.cs
+++ b/OLED-Sleeper/Features/UserSettings/Handlers/ApplySettingsChangeCommandHandler.cs
@@ -1,4 +1,4 @@
-using OLED_Sleeper.Features.MonitorBehavior.Commands;
+﻿using OLED_Sleeper.Features.MonitorBehavior.Commands;
 using OLED_Sleeper.Features.MonitorIdleDetection.Services.Interfaces;
 using OLED_Sleeper.Features.MonitorInformation.Services.Interfaces;
 using OLED_Sleeper.Features.UserSettings.Commands;

--- a/OLED-Sleeper/Native/NativeMethods.cs
+++ b/OLED-Sleeper/Native/NativeMethods.cs
@@ -163,6 +163,16 @@ namespace OLED_Sleeper.Native
         }
 
         /// <summary>
+        /// Set in <see cref="MonitorInfoEx.dwFlags"/> when the monitor is the primary display.
+        /// </summary>
+        public const uint MONITORINFOF_PRIMARY = 0x1;
+
+        /// <summary>
+        /// Set in <see cref="DISPLAY_DEVICE.StateFlags"/> when the adapter is part of the desktop.
+        /// </summary>
+        public const uint DISPLAY_DEVICE_ATTACHED_TO_DESKTOP = 0x1;
+
+        /// <summary>
         /// Specifies the type of DPI being queried.
         /// </summary>
         public enum MonitorDpiType

--- a/OLED-Sleeper/UI/ViewModels/MonitorConfigurationViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MonitorConfigurationViewModel.cs
@@ -53,7 +53,7 @@ namespace OLED_Sleeper.UI.ViewModels
         /// <summary>
         /// Gets a value indicating whether the "Dim" behavior option should be enabled.
         /// </summary>
-        public bool IsDimBehaviorEnabled => _monitorInfo.IsDdcCiSupported;
+        public bool IsDimBehaviorEnabled => _monitorInfo.Capabilities?.IsSupported == true;
 
         /// <summary>
         /// Gets the tooltip for the entire Behavior section, changing based on DDC/CI support.
@@ -66,7 +66,7 @@ namespace OLED_Sleeper.UI.ViewModels
                                     "• Blackout: Turns the monitor completely black.\n" +
                                      "• Dim: Reduces the monitor's brightness using DDC/CI.";
 
-                if (!_monitorInfo.IsDdcCiSupported)
+                if (_monitorInfo.Capabilities?.IsSupported != true)
                 {
                     baseTooltip = "THE SELECTED MONITOR DOES NOT SUPPORT DIMMING.\n\n" + baseTooltip;
                 }


### PR DESCRIPTION
Display changes are now detected by pairing panels on hardware ID rather than `\.\DISPLAYn`, and the hardware ID is read in the same pass as the geometry so the two describe the same instant.

* Not a confirmed fix for #53. The assumed trigger was not reproduced locally, and two of the three displays there are virtual.
* DDC/CI writes still address the panel by cached device name in `MonitorDimmingService.WithSessionAsync`, so a stale pairing sends a brightness write to the wrong panel.
* `MonitorSettingsSaveService.TrySave` can still persist a hardware ID the cache got wrong.
* A hardware ID that resolves in only one of two readings falls back to pairing by device name. Two readings that both resolve, to different IDs, never pair.
* `MonitorInfo` carries `DdcCiCapabilities?` in place of `IsDdcCiSupported` and `MaxBrightness`. Null means not probed.
* `GetHardwareId` is gone from `IMonitorInfoProvider`. `GetAllMonitorsBasicInfo` walks the display adapters once and fills hardware ID and geometry in the same pass.
