### PR TITLE
fix: keep the blackout overlay above the taskbar and other topmost windows

### DIFF
--- a/OLED-Sleeper/Features/MonitorBlackout/Services/OverlayWindow.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Services/OverlayWindow.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
+using System.Windows.Threading;
 
 namespace OLED_Sleeper.Features.MonitorBlackout.Services
 {
@@ -13,6 +14,11 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
     [ExcludeFromCodeCoverage]
     public class OverlayWindow : IOverlayWindow
     {
+        /// <summary>
+        /// How often the overlay returns itself to the top of the topmost band while it is shown.
+        /// </summary>
+        private static readonly TimeSpan TopmostReassertInterval = TimeSpan.FromSeconds(1);
+
         /// <summary>
         /// The black, borderless, topmost window shown over the monitor. Its startup location is manual
         /// so that <see cref="Show"/> can place it in physical pixels.
@@ -29,6 +35,19 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
             WindowStartupLocation = WindowStartupLocation.Manual
         };
 
+        /// <summary>
+        /// Runs on the UI thread between <see cref="Show"/> and <see cref="Close"/>. Windows orders
+        /// topmost windows among themselves, so the taskbar and other topmost windows sit above the
+        /// overlay from the moment they are shown or activated until it re-asserts its z-order.
+        /// </summary>
+        private readonly DispatcherTimer _topmostTimer;
+
+        public OverlayWindow()
+        {
+            _topmostTimer = new DispatcherTimer { Interval = TopmostReassertInterval };
+            _topmostTimer.Tick += (_, _) => ReassertTopmost();
+        }
+
         /// <inheritdoc />
         public nint Handle => new WindowInteropHelper(_window).Handle;
 
@@ -42,10 +61,16 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
 
             ApplyNoActivateStyle(hwnd);
             PositionToMonitor(hwnd, bounds);
+            _topmostTimer.Start();
         }
 
         /// <inheritdoc />
-        public void Close() => _window.Close();
+        public void Close()
+        {
+            // A running DispatcherTimer is held by the dispatcher, which keeps this overlay alive.
+            _topmostTimer.Stop();
+            _window.Close();
+        }
 
         #region Private Helpers
 
@@ -75,6 +100,22 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Services
             nint extendedStyle = NativeMethods.GetWindowLongPtr(hwnd, NativeMethods.GWL_EXSTYLE);
             NativeMethods.SetWindowLongPtr(hwnd, NativeMethods.GWL_EXSTYLE,
                 new nint(extendedStyle.ToInt64() | NativeMethods.WS_EX_NOACTIVATE));
+        }
+
+        /// <summary>
+        /// Returns the overlay to the top of the topmost band, leaving its position, size and the
+        /// active window untouched. Does nothing once the overlay has been closed.
+        /// </summary>
+        private void ReassertTopmost()
+        {
+            nint hwnd = Handle;
+            if (hwnd == nint.Zero) return;
+
+            NativeMethods.SetWindowPos(
+                hwnd,
+                NativeMethods.HWND_TOPMOST,
+                0, 0, 0, 0,
+                NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE);
         }
 
         #endregion Private Helpers

--- a/OLED-Sleeper/Native/NativeMethods.cs
+++ b/OLED-Sleeper/Native/NativeMethods.cs
@@ -195,6 +195,16 @@ namespace OLED_Sleeper.Native
         public const uint SWP_NOACTIVATE = 0x0010;
 
         /// <summary>
+        /// Retains the window's current size.
+        /// </summary>
+        public const uint SWP_NOSIZE = 0x0001;
+
+        /// <summary>
+        /// Retains the window's current position.
+        /// </summary>
+        public const uint SWP_NOMOVE = 0x0002;
+
+        /// <summary>
         /// Use with <see cref="DwmGetWindowAttribute"/> to get the extended frame bounds rectangle.
         /// </summary>
         public const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;


### PR DESCRIPTION
The blackout overlay re-asserts its topmost position once a second, so the taskbar and other topmost windows stay covered.

* This hides notifications on a blacked-out monitor. Flashing taskbar buttons and toasts are now covered rather than left visible.
* The one-second interval is a judgement call, not a measured one. A competing app that re-asserts faster would flicker; AIMP's OSD is the case to check first.
* No tests. `OverlayWindow` is `[ExcludeFromCodeCoverage]` and holds the `Window`, `WindowInteropHelper` and `NativeMethods` calls by design, so verification is manual.
* Reaching a re-covered taskbar depends on the activity source: cursor-position and system-input detection wake the monitor, `IsActiveOnActiveWindow` alone does not.
* The re-assert passes `SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE` and no-ops on a zero handle, and the `DispatcherTimer` is stopped before `Close` so it cannot root the overlay after teardown.
