### PR TITLE
fix: keep monitors blank when the desktop, not an application, takes focus

### DIFF
--- a/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
+++ b/OLED-Sleeper/Features/MonitorIdleDetection/Services/MonitorIdleDetectionService.cs
@@ -7,6 +7,7 @@ using OLED_Sleeper.Messaging.Interfaces;
 using OLED_Sleeper.Native;
 using Serilog;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Windows;
 
 namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
@@ -17,6 +18,21 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
     /// </summary>
     public class MonitorIdleDetectionService : IMonitorIdleDetectionService
     {
+        /// <summary>
+        /// Window classes that make up the shell desktop. The desktop spans the whole virtual screen, so
+        /// it never counts as active-window activity for any monitor.
+        /// </summary>
+        private static readonly HashSet<string> DesktopWindowClasses = new(StringComparer.Ordinal)
+        {
+            "Progman",
+            "WorkerW"
+        };
+
+        /// <summary>
+        /// Buffer size, in characters, for a window class name.
+        /// </summary>
+        private const int ClassNameBufferLength = 256;
+
         // === Dependencies & State ===
         private readonly IMediator _mediator;
 
@@ -290,8 +306,25 @@ namespace OLED_Sleeper.Features.MonitorIdleDetection.Services
             NativeMethods.GetCursorPos(out var nativePoint);
             Point cursorPosition = new(nativePoint.X, nativePoint.Y);
             nint foregroundWindowHandle = NativeMethods.GetForegroundWindow();
-            Rect windowRect = GetForegroundWindowRect(foregroundWindowHandle);
+            Rect windowRect = IsDesktopWindow(foregroundWindowHandle)
+                ? Rect.Empty
+                : GetForegroundWindowRect(foregroundWindowHandle);
             return new SystemState(idleTime, cursorPosition, windowRect, foregroundWindowHandle);
+        }
+
+        /// <summary>
+        /// Determines whether a window is the shell desktop rather than an application window.
+        /// </summary>
+        /// <param name="hwnd">The handle to test.</param>
+        /// <returns>True when the window belongs to one of the <see cref="DesktopWindowClasses"/>; false for a null handle or a class name the shell would not answer.</returns>
+        private static bool IsDesktopWindow(nint hwnd)
+        {
+            if (hwnd == nint.Zero) return false;
+
+            var className = new StringBuilder(ClassNameBufferLength);
+            if (NativeMethods.GetClassName(hwnd, className, className.Capacity) == 0) return false;
+
+            return DesktopWindowClasses.Contains(className.ToString());
         }
 
         /// <summary>

--- a/OLED-Sleeper/Native/NativeMethods.cs
+++ b/OLED-Sleeper/Native/NativeMethods.cs
@@ -101,6 +101,17 @@ namespace OLED_Sleeper.Native
         [DllImport("user32.dll")]
         public static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
 
+        /// <summary>
+        /// Retrieves the name of the class to which the specified window belongs.
+        /// </summary>
+        /// <param name="hWnd">A handle to the window.</param>
+        /// <param name="lpClassName">The buffer that receives the class name.</param>
+        /// <param name="nMaxCount">The length of the buffer, in characters.</param>
+        /// <returns>The number of characters copied, excluding the terminating null; zero on failure.</returns>
+        /// <seealso href="https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getclassnamew"/>
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern int GetClassName(IntPtr hWnd, System.Text.StringBuilder lpClassName, int nMaxCount);
+
         #endregion User Input and Window Management
 
         #region Monitor and Display Configuration


### PR DESCRIPTION
Fixes #81, where a monitor blanked under "Application is focused on this monitor" woke when another monitor's desktop was clicked or Win+D was pressed.

* A monitor whose only enabled condition is "Application is focused on this monitor" now starts its idle countdown while the desktop is showing on it.
* The shell desktop is one window spanning the whole virtual screen, so its rect intersected every managed monitor's bounds. Progman and WorkerW now yield an empty foreground rect.
* No unit test covers this. The state machine has no test seam, so it was verified by reading the live Progman rect (-1872,0)-(2688,1152) against three attached displays.
* Task View and Alt-Tab are also full-virtual-screen shell surfaces and are not in the class list.
* Mouse-position and system-input conditions and the overlay filter in ApplyMonitorActiveBehaviorCommandHandler are untouched.
