### PR TITLE
fix: identify and dim the real panel when a display is duplicated

### DIFF
--- a/OLED-Sleeper/Features/MonitorDimming/Services/DdcCiAccess.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/DdcCiAccess.cs
@@ -18,10 +18,42 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
             var hMonitor = FindMonitorHandle(deviceName);
             if (hMonitor == nint.Zero) return null;
 
-            var physicalMonitors = new NativeMethods.PHYSICAL_MONITOR[1];
-            if (!NativeMethods.GetPhysicalMonitorsFromHMONITOR(hMonitor, 1, physicalMonitors)) return null;
+            if (!NativeMethods.GetNumberOfPhysicalMonitorsFromHMONITOR(hMonitor, out uint count) || count == 0)
+            {
+                count = 1;
+            }
 
-            return new DdcCiSession(physicalMonitors);
+            var physicalMonitors = new NativeMethods.PHYSICAL_MONITOR[count];
+            if (!NativeMethods.GetPhysicalMonitorsFromHMONITOR(hMonitor, count, physicalMonitors)) return null;
+
+            int index = count == 1 ? 0 : FindRespondingMonitor(physicalMonitors);
+            if (index < 0)
+            {
+                NativeMethods.DestroyPhysicalMonitors(count, physicalMonitors);
+                return null;
+            }
+
+            return new DdcCiSession(physicalMonitors, index);
+        }
+
+        /// <summary>
+        /// Finds the physical monitor that answers DDC/CI. A duplicated desktop surface hands back one physical
+        /// monitor per panel in no useful order, and a virtual display can be the one that comes first.
+        /// </summary>
+        /// <param name="physicalMonitors">The physical monitors behind one display monitor handle.</param>
+        /// <returns>The index of the first monitor that answered, or -1 when none did.</returns>
+        private static int FindRespondingMonitor(NativeMethods.PHYSICAL_MONITOR[] physicalMonitors)
+        {
+            for (int index = 0; index < physicalMonitors.Length; index++)
+            {
+                if (NativeMethods.GetVCPFeatureAndVCPFeatureReply(
+                        physicalMonitors[index].hPhysicalMonitor, NativeMethods.VCP_CODE_BRIGHTNESS, nint.Zero, out _, out _))
+                {
+                    return index;
+                }
+            }
+
+            return -1;
         }
 
         /// <summary>

--- a/OLED-Sleeper/Features/MonitorDimming/Services/DdcCiSession.cs
+++ b/OLED-Sleeper/Features/MonitorDimming/Services/DdcCiSession.cs
@@ -14,10 +14,12 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
         private readonly nint _hPhysicalMonitor;
         private bool _disposed;
 
-        internal DdcCiSession(NativeMethods.PHYSICAL_MONITOR[] physicalMonitors)
+        /// <param name="physicalMonitors">Every physical monitor behind one display monitor handle. All are released together.</param>
+        /// <param name="index">The monitor within that set this channel talks to.</param>
+        internal DdcCiSession(NativeMethods.PHYSICAL_MONITOR[] physicalMonitors, int index)
         {
             _physicalMonitors = physicalMonitors;
-            _hPhysicalMonitor = physicalMonitors[0].hPhysicalMonitor;
+            _hPhysicalMonitor = physicalMonitors[index].hPhysicalMonitor;
         }
 
         /// <inheritdoc />
@@ -46,7 +48,7 @@ namespace OLED_Sleeper.Features.MonitorDimming.Services
             if (_disposed) return;
 
             _disposed = true;
-            NativeMethods.DestroyPhysicalMonitors(1, _physicalMonitors);
+            NativeMethods.DestroyPhysicalMonitors((uint)_physicalMonitors.Length, _physicalMonitors);
         }
     }
 }

--- a/OLED-Sleeper/Features/MonitorInformation/Models/MonitorInfo.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Models/MonitorInfo.cs
@@ -21,6 +21,12 @@ namespace OLED_Sleeper.Features.MonitorInformation.Models
         public string HardwareId { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets how Windows numbers the panels showing this desktop surface, such as <c>1|2</c> for a
+        /// duplicated one. Empty when the surface is not duplicated.
+        /// </summary>
+        public string TopologyLabel { get; set; } = string.Empty;
+
+        /// <summary>
         /// Gets or sets the bounding rectangle of the monitor in screen coordinates.
         /// </summary>
         public Rect Bounds { get; set; }

--- a/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoProvider.cs
+++ b/OLED-Sleeper/Features/MonitorInformation/Services/MonitorInfoProvider.cs
@@ -1,4 +1,4 @@
-﻿using OLED_Sleeper.Features.MonitorInformation.Models;
+using OLED_Sleeper.Features.MonitorInformation.Models;
 using OLED_Sleeper.Features.MonitorInformation.Services.Interfaces;
 using OLED_Sleeper.Native;
 using Serilog;
@@ -17,7 +17,7 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
         /// <inheritdoc />
         public List<MonitorInfo> GetAllMonitorsBasicInfo()
         {
-            var hardwareIdsByDeviceName = MapDeviceNamesToHardwareIds();
+            var identitiesByDeviceName = MapDeviceNamesToIdentities();
             var monitors = new List<MonitorInfo>();
 
             NativeMethods.MonitorEnumProc callback = (IntPtr hMonitor, IntPtr hdcMonitor, ref NativeMethods.Rect lprcMonitor, IntPtr dwData) =>
@@ -26,9 +26,9 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
                 if (NativeMethods.GetMonitorInfo(hMonitor, ref mi))
                 {
                     NativeMethods.GetDpiForMonitor(hMonitor, NativeMethods.MonitorDpiType.MDT_EFFECTIVE_DPI, out uint dpiX, out _);
-                    hardwareIdsByDeviceName.TryGetValue(mi.szDevice, out var hardwareId);
+                    identitiesByDeviceName.TryGetValue(mi.szDevice, out var identity);
 
-                    if (string.IsNullOrEmpty(hardwareId))
+                    if (string.IsNullOrEmpty(identity.HardwareId))
                     {
                         Log.Debug("No hardware ID resolved for {DeviceName}.", mi.szDevice);
                     }
@@ -36,7 +36,8 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
                     monitors.Add(new MonitorInfo
                     {
                         DeviceName = mi.szDevice,
-                        HardwareId = hardwareId ?? string.Empty,
+                        HardwareId = identity.HardwareId ?? string.Empty,
+                        TopologyLabel = identity.TopologyLabel ?? string.Empty,
                         Bounds = new Rect(
                             mi.rcMonitor.left,
                             mi.rcMonitor.top,
@@ -66,55 +67,215 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
                 mi.cbSize = Marshal.SizeOf(mi);
                 if (NativeMethods.GetMonitorInfo(hMonitor, ref mi) && mi.szDevice == deviceName)
                 {
-                    var physicalMonitors = new NativeMethods.PHYSICAL_MONITOR[1];
-                    if (NativeMethods.GetPhysicalMonitorsFromHMONITOR(hMonitor, 1, physicalMonitors))
+                    uint count = CountPhysicalMonitors(hMonitor);
+                    var physicalMonitors = new NativeMethods.PHYSICAL_MONITOR[count];
+                    if (NativeMethods.GetPhysicalMonitorsFromHMONITOR(hMonitor, count, physicalMonitors))
                     {
-                        nint hPhysicalMonitor = physicalMonitors[0].hPhysicalMonitor;
-                        if (NativeMethods.GetCapabilitiesStringLength(hPhysicalMonitor, out _))
+                        foreach (var physicalMonitor in physicalMonitors)
                         {
+                            if (!NativeMethods.GetCapabilitiesStringLength(physicalMonitor.hPhysicalMonitor, out _)) continue;
+
                             isSupported = true;
 
                             if (NativeMethods.GetVCPFeatureAndVCPFeatureReply(
-                                    hPhysicalMonitor, NativeMethods.VCP_CODE_BRIGHTNESS, nint.Zero, out _, out var reportedMax))
+                                    physicalMonitor.hPhysicalMonitor, NativeMethods.VCP_CODE_BRIGHTNESS, nint.Zero, out _, out var reportedMax))
                             {
                                 maxBrightness = reportedMax;
                             }
+                            break;
                         }
-                        NativeMethods.DestroyPhysicalMonitors(1, physicalMonitors);
+                        NativeMethods.DestroyPhysicalMonitors(count, physicalMonitors);
                     }
                 }
                 return !isSupported; // Stop enumerating once we've found and checked our monitor.
             };
 
             NativeMethods.EnumDisplayMonitors(nint.Zero, nint.Zero, callback, nint.Zero);
-            Log.Debug("DDC/CI probe for monitor with DeviceName {DeviceName}: supported {IsSupported}, maximum brightness {MaxBrightness}.",
-                deviceName, isSupported, maxBrightness);
+            Log.Debug("DDC/CI probe for {HardwareId} on {DeviceName}: supported {IsSupported}, maximum brightness {MaxBrightness}.",
+                monitor.HardwareId, deviceName, isSupported, maxBrightness);
             return new DdcCiCapabilities(isSupported, maxBrightness);
         }
 
         /// <summary>
-        /// Walks the attached display adapters once and maps each adapter's device name to the hardware ID
-        /// of the monitor on it.
+        /// Counts the physical monitors behind a display monitor handle. A duplicated desktop surface has one
+        /// per panel, and <see cref="NativeMethods.GetPhysicalMonitorsFromHMONITOR"/> fails outright unless the
+        /// array it is handed is exactly that size.
         /// </summary>
-        /// <returns>The hardware ID for each adapter that reported one.</returns>
-        private static Dictionary<string, string> MapDeviceNamesToHardwareIds()
+        /// <param name="hMonitor">Handle to the display monitor.</param>
+        /// <returns>The number of physical monitors, or one when the count could not be read.</returns>
+        private static uint CountPhysicalMonitors(nint hMonitor)
         {
-            var hardwareIdsByDeviceName = new Dictionary<string, string>();
+            if (!NativeMethods.GetNumberOfPhysicalMonitorsFromHMONITOR(hMonitor, out uint count) || count == 0)
+            {
+                return 1;
+            }
+
+            return count;
+        }
+
+        /// <summary>
+        /// Walks the attached display adapters once and works out which monitor each adapter's desktop
+        /// surface belongs to.
+        /// </summary>
+        /// <returns>The identity of each adapter that resolved one.</returns>
+        private static Dictionary<string, MonitorIdentity> MapDeviceNamesToIdentities()
+        {
+            var identitiesByDeviceName = new Dictionary<string, MonitorIdentity>();
             var adapter = new NativeMethods.DISPLAY_DEVICE { cb = Marshal.SizeOf(typeof(NativeMethods.DISPLAY_DEVICE)) };
+            List<DisplayPath>? displayPaths = null;
 
             for (uint adapterIndex = 0; NativeMethods.EnumDisplayDevices(null, adapterIndex, ref adapter, 0); adapterIndex++)
             {
                 if ((adapter.StateFlags & NativeMethods.DISPLAY_DEVICE_ATTACHED_TO_DESKTOP) == 0) continue;
 
-                var monitorDevice = new NativeMethods.DISPLAY_DEVICE { cb = Marshal.SizeOf(typeof(NativeMethods.DISPLAY_DEVICE)) };
-                if (!NativeMethods.EnumDisplayDevices(adapter.DeviceName, 0, ref monitorDevice, 0)) continue;
-                if (string.IsNullOrEmpty(monitorDevice.DeviceID)) continue;
+                var hardwareIds = ReadMonitorHardwareIds(adapter.DeviceName);
+                if (hardwareIds.Count == 0) continue;
 
-                hardwareIdsByDeviceName[adapter.DeviceName] = monitorDevice.DeviceID;
-                Log.Debug("HWID for monitor {DeviceName}: {HWID}", adapter.DeviceName, monitorDevice.DeviceID);
+                var identity = hardwareIds.Count == 1
+                    ? new MonitorIdentity(hardwareIds[0], string.Empty)
+                    : ResolveDuplicatedIdentity(adapter.DeviceName, hardwareIds, displayPaths ??= ReadActiveDisplayPaths());
+
+                if (string.IsNullOrEmpty(identity.HardwareId)) continue;
+
+                identitiesByDeviceName[adapter.DeviceName] = identity;
             }
 
-            return hardwareIdsByDeviceName;
+            return identitiesByDeviceName;
+        }
+
+        /// <summary>
+        /// Reads the hardware ID of every monitor an adapter reports, by child index.
+        /// </summary>
+        /// <param name="adapterDeviceName">The adapter's device name, such as <c>\\.\DISPLAY1</c>.</param>
+        /// <returns>The hardware IDs, with an empty entry for any child that reported none.</returns>
+        private static List<string> ReadMonitorHardwareIds(string adapterDeviceName)
+        {
+            var hardwareIds = new List<string>();
+            var monitorDevice = new NativeMethods.DISPLAY_DEVICE { cb = Marshal.SizeOf(typeof(NativeMethods.DISPLAY_DEVICE)) };
+
+            for (uint childIndex = 0; NativeMethods.EnumDisplayDevices(adapterDeviceName, childIndex, ref monitorDevice, 0); childIndex++)
+            {
+                hardwareIds.Add(monitorDevice.DeviceID ?? string.Empty);
+            }
+
+            return hardwareIds;
+        }
+
+        /// <summary>
+        /// Works out the identity of an adapter reporting more than one monitor, which is what a duplicated
+        /// desktop surface looks like. The children come in no useful order — a virtual display can sit at
+        /// index zero while the panel the surface belongs to sits below it — so the active display paths
+        /// decide: the panel this adapter's own path drives is the monitor, and every child holding a path of
+        /// its own contributes its display number to the label Windows shows, such as <c>1|2</c>.
+        /// </summary>
+        /// <param name="adapterDeviceName">The adapter's device name, such as <c>\\.\DISPLAY1</c>.</param>
+        /// <param name="hardwareIds">The adapter's hardware IDs, by child index.</param>
+        /// <param name="displayPaths">The active display paths, in the order Windows numbers them.</param>
+        /// <returns>The identity, falling back to the first child when no path named the surface's panel.</returns>
+        private static MonitorIdentity ResolveDuplicatedIdentity(
+            string adapterDeviceName, List<string> hardwareIds, List<DisplayPath> displayPaths)
+        {
+            string surfaceDevicePath = displayPaths
+                .FirstOrDefault(path => string.Equals(path.GdiDeviceName, adapterDeviceName, StringComparison.OrdinalIgnoreCase))
+                .DevicePath ?? string.Empty;
+
+            var monitorDevice = new NativeMethods.DISPLAY_DEVICE { cb = Marshal.SizeOf(typeof(NativeMethods.DISPLAY_DEVICE)) };
+            string hardwareId = string.Empty;
+            var displayNumbers = new List<int>();
+
+            for (uint childIndex = 0; childIndex < hardwareIds.Count; childIndex++)
+            {
+                if (!NativeMethods.EnumDisplayDevices(
+                        adapterDeviceName, childIndex, ref monitorDevice, NativeMethods.EDD_GET_DEVICE_INTERFACE_NAME))
+                {
+                    break;
+                }
+
+                string devicePath = monitorDevice.DeviceID ?? string.Empty;
+                if (devicePath.Length == 0) continue;
+
+                if (string.Equals(devicePath, surfaceDevicePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    hardwareId = hardwareIds[(int)childIndex];
+                }
+
+                int pathIndex = displayPaths.FindIndex(
+                    path => string.Equals(path.DevicePath, devicePath, StringComparison.OrdinalIgnoreCase));
+
+                if (pathIndex >= 0) displayNumbers.Add(pathIndex + 1);
+            }
+
+            if (hardwareId.Length == 0)
+            {
+                Log.Debug("{DeviceName} reports {Count} monitors and no active display path named one of them. Falling back to {HardwareId}.",
+                    adapterDeviceName, hardwareIds.Count, hardwareIds[0]);
+                hardwareId = hardwareIds[0];
+            }
+
+            displayNumbers.Sort();
+            string topologyLabel = displayNumbers.Count > 1 ? string.Join('|', displayNumbers) : string.Empty;
+            return new MonitorIdentity(hardwareId, topologyLabel);
+        }
+
+        /// <summary>
+        /// Reads the display paths that make up the current desktop, in the order Windows numbers them:
+        /// the first path is display 1.
+        /// </summary>
+        /// <returns>The active paths, empty when the display configuration could not be read.</returns>
+        private static List<DisplayPath> ReadActiveDisplayPaths()
+        {
+            var displayPaths = new List<DisplayPath>();
+
+            if (NativeMethods.GetDisplayConfigBufferSizes(
+                    NativeMethods.QDC_ONLY_ACTIVE_PATHS, out uint pathCount, out uint modeCount) != 0)
+            {
+                return displayPaths;
+            }
+
+            var paths = new NativeMethods.DISPLAYCONFIG_PATH_INFO[pathCount];
+            var modes = new NativeMethods.DISPLAYCONFIG_MODE_INFO[modeCount];
+
+            if (NativeMethods.QueryDisplayConfig(
+                    NativeMethods.QDC_ONLY_ACTIVE_PATHS, ref pathCount, paths, ref modeCount, modes, nint.Zero) != 0)
+            {
+                return displayPaths;
+            }
+
+            for (uint pathIndex = 0; pathIndex < pathCount; pathIndex++)
+            {
+                var path = paths[pathIndex];
+
+                var sourceName = new NativeMethods.DISPLAYCONFIG_SOURCE_DEVICE_NAME
+                {
+                    header = new NativeMethods.DISPLAYCONFIG_DEVICE_INFO_HEADER
+                    {
+                        type = NativeMethods.DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME,
+                        size = (uint)Marshal.SizeOf(typeof(NativeMethods.DISPLAYCONFIG_SOURCE_DEVICE_NAME)),
+                        adapterId = path.sourceInfo.adapterId,
+                        id = path.sourceInfo.id
+                    }
+                };
+
+                var targetName = new NativeMethods.DISPLAYCONFIG_TARGET_DEVICE_NAME
+                {
+                    header = new NativeMethods.DISPLAYCONFIG_DEVICE_INFO_HEADER
+                    {
+                        type = NativeMethods.DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME,
+                        size = (uint)Marshal.SizeOf(typeof(NativeMethods.DISPLAYCONFIG_TARGET_DEVICE_NAME)),
+                        adapterId = path.targetInfo.adapterId,
+                        id = path.targetInfo.id
+                    }
+                };
+
+                bool sourceRead = NativeMethods.DisplayConfigGetDeviceInfo(ref sourceName) == 0;
+                bool targetRead = NativeMethods.DisplayConfigGetDeviceInfo(ref targetName) == 0;
+
+                displayPaths.Add(new DisplayPath(
+                    sourceRead ? sourceName.viewGdiDeviceName : string.Empty,
+                    targetRead ? targetName.monitorDevicePath : string.Empty));
+            }
+
+            return displayPaths;
         }
 
         /// <summary>
@@ -131,5 +292,19 @@ namespace OLED_Sleeper.Features.MonitorInformation.Services
             }
             return -1;
         }
+
+        /// <summary>
+        /// What a desktop surface is: the monitor it belongs to, and how Windows numbers the panels showing it.
+        /// </summary>
+        /// <param name="HardwareId">The hardware ID of the monitor the surface belongs to.</param>
+        /// <param name="TopologyLabel">The display numbers sharing the surface, such as <c>1|2</c>. Empty when it is not duplicated.</param>
+        private readonly record struct MonitorIdentity(string HardwareId, string TopologyLabel);
+
+        /// <summary>
+        /// One active display path: a desktop surface and the panel it drives.
+        /// </summary>
+        /// <param name="GdiDeviceName">The source's GDI device name, such as <c>\\.\DISPLAY1</c>.</param>
+        /// <param name="DevicePath">The target's device interface path.</param>
+        private readonly record struct DisplayPath(string GdiDeviceName, string DevicePath);
     }
 }

--- a/OLED-Sleeper/Features/MonitorState/Helpers/DisplaySetComparer.cs
+++ b/OLED-Sleeper/Features/MonitorState/Helpers/DisplaySetComparer.cs
@@ -96,7 +96,8 @@ namespace OLED_Sleeper.Features.MonitorState.Helpers
                 && first.Bounds == second.Bounds
                 && first.Dpi == second.Dpi
                 && first.IsPrimary == second.IsPrimary
-                && first.DisplayNumber == second.DisplayNumber;
+                && first.DisplayNumber == second.DisplayNumber
+                && first.TopologyLabel == second.TopologyLabel;
         }
     }
 }

--- a/OLED-Sleeper/Native/NativeMethods.cs
+++ b/OLED-Sleeper/Native/NativeMethods.cs
@@ -184,6 +184,12 @@ namespace OLED_Sleeper.Native
         public const uint DISPLAY_DEVICE_ATTACHED_TO_DESKTOP = 0x1;
 
         /// <summary>
+        /// Passed to <see cref="EnumDisplayDevices"/> to return the device interface path in
+        /// <see cref="DISPLAY_DEVICE.DeviceID"/> instead of the monitor's hardware ID.
+        /// </summary>
+        public const uint EDD_GET_DEVICE_INTERFACE_NAME = 0x1;
+
+        /// <summary>
         /// Specifies the type of DPI being queried.
         /// </summary>
         public enum MonitorDpiType
@@ -325,9 +331,10 @@ namespace OLED_Sleeper.Native
         public const byte VCP_CODE_BRIGHTNESS = 0x10;
 
         /// <summary>
-        /// Represents a handle to a physical monitor.
+        /// Represents a handle to a physical monitor. The description is a wide string, so the struct is
+        /// 264 bytes; marshalling it as ANSI hands dxva2 a 136-byte buffer to write 264 bytes into.
         /// </summary>
-        [StructLayout(LayoutKind.Sequential)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public struct PHYSICAL_MONITOR
         {
             public IntPtr hPhysicalMonitor;
@@ -346,6 +353,17 @@ namespace OLED_Sleeper.Native
         [DllImport("dxva2.dll", EntryPoint = "DestroyPhysicalMonitors")]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool DestroyPhysicalMonitors(uint dwPhysicalMonitorArraySize, [In] PHYSICAL_MONITOR[] pPhysicalMonitorArray);
+
+        /// <summary>
+        /// Retrieves the number of physical monitors behind a display monitor handle.
+        /// </summary>
+        /// <param name="hMonitor">Handle to the display monitor.</param>
+        /// <param name="pdwNumberOfPhysicalMonitors">Receives the number of physical monitors.</param>
+        /// <returns>True if successful; otherwise, false.</returns>
+        /// <seealso href="https://learn.microsoft.com/en-us/windows/win32/api/dxva2/nf-dxva2-getnumberofphysicalmonitorsfromhmonitor"/>
+        [DllImport("dxva2.dll", EntryPoint = "GetNumberOfPhysicalMonitorsFromHMONITOR")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetNumberOfPhysicalMonitorsFromHMONITOR(IntPtr hMonitor, out uint pdwNumberOfPhysicalMonitors);
 
         /// <summary>
         /// Retrieves the physical monitors associated with a display monitor handle.
@@ -399,6 +417,197 @@ namespace OLED_Sleeper.Native
         public static extern bool GetCapabilitiesStringLength(IntPtr hPhysicalMonitor, out uint pdwCapabilitiesStringLengthInCharacters);
 
         #endregion DDC/CI (Monitor Brightness)
+
+        #region Display Configuration (CCD)
+
+        /// <summary>
+        /// Restricts a <see cref="QueryDisplayConfig"/> query to paths that are currently in use.
+        /// </summary>
+        public const uint QDC_ONLY_ACTIVE_PATHS = 0x2;
+
+        /// <summary>
+        /// Asks <see cref="DisplayConfigGetDeviceInfo(ref DISPLAYCONFIG_SOURCE_DEVICE_NAME)"/> for the GDI device name of a source.
+        /// </summary>
+        public const uint DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME = 1;
+
+        /// <summary>
+        /// Asks <see cref="DisplayConfigGetDeviceInfo(ref DISPLAYCONFIG_TARGET_DEVICE_NAME)"/> for the name and device path of a target.
+        /// </summary>
+        public const uint DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME = 2;
+
+        /// <summary>
+        /// Locally unique identifier for a display adapter.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct LUID
+        {
+            public uint LowPart;
+            public int HighPart;
+        }
+
+        /// <summary>
+        /// Describes the source (the desktop surface) end of a display path.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct DISPLAYCONFIG_PATH_SOURCE_INFO
+        {
+            public LUID adapterId;
+            public uint id;
+            public uint modeInfoIdx;
+            public uint statusFlags;
+        }
+
+        /// <summary>
+        /// A ratio of two unsigned integers, used for refresh rates.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct DISPLAYCONFIG_RATIONAL
+        {
+            public uint Numerator;
+            public uint Denominator;
+        }
+
+        /// <summary>
+        /// Describes the target (the panel) end of a display path.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct DISPLAYCONFIG_PATH_TARGET_INFO
+        {
+            public LUID adapterId;
+            public uint id;
+            public uint modeInfoIdx;
+            public uint outputTechnology;
+            public uint rotation;
+            public uint scaling;
+            public DISPLAYCONFIG_RATIONAL refreshRate;
+            public uint scanLineOrdering;
+
+            [MarshalAs(UnmanagedType.Bool)]
+            public bool targetAvailable;
+
+            public uint statusFlags;
+        }
+
+        /// <summary>
+        /// One source-to-target display path.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct DISPLAYCONFIG_PATH_INFO
+        {
+            public DISPLAYCONFIG_PATH_SOURCE_INFO sourceInfo;
+            public DISPLAYCONFIG_PATH_TARGET_INFO targetInfo;
+            public uint flags;
+        }
+
+        /// <summary>
+        /// A mode entry. The 48-byte payload is a union this application does not read; only the size matters,
+        /// because <see cref="QueryDisplayConfig"/> refuses to run without a mode array to fill.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct DISPLAYCONFIG_MODE_INFO
+        {
+            public uint infoType;
+            public uint id;
+            public LUID adapterId;
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 48)]
+            public byte[] union;
+        }
+
+        /// <summary>
+        /// Names the request and its subject for a <see cref="DisplayConfigGetDeviceInfo(ref DISPLAYCONFIG_SOURCE_DEVICE_NAME)"/> call.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct DISPLAYCONFIG_DEVICE_INFO_HEADER
+        {
+            public uint type;
+            public uint size;
+            public LUID adapterId;
+            public uint id;
+        }
+
+        /// <summary>
+        /// Receives the GDI device name, such as <c>\\.\DISPLAY1</c>, of a display path's source.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct DISPLAYCONFIG_SOURCE_DEVICE_NAME
+        {
+            public DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+            public string viewGdiDeviceName;
+        }
+
+        /// <summary>
+        /// Receives the friendly name and device interface path of a display path's target.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct DISPLAYCONFIG_TARGET_DEVICE_NAME
+        {
+            public DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+            public uint flags;
+            public uint outputTechnology;
+            public ushort edidManufactureId;
+            public ushort edidProductCodeId;
+            public uint connectorInstance;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)]
+            public string monitorFriendlyDeviceName;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+            public string monitorDevicePath;
+        }
+
+        /// <summary>
+        /// Retrieves the array sizes <see cref="QueryDisplayConfig"/> needs.
+        /// </summary>
+        /// <param name="flags">The topology to size for, such as <see cref="QDC_ONLY_ACTIVE_PATHS"/>.</param>
+        /// <param name="numPathArrayElements">Receives the number of path elements.</param>
+        /// <param name="numModeInfoArrayElements">Receives the number of mode elements.</param>
+        /// <returns>ERROR_SUCCESS (0) on success; otherwise, a Win32 error code.</returns>
+        /// <seealso href="https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdisplayconfigbuffersizes"/>
+        [DllImport("user32.dll", EntryPoint = "GetDisplayConfigBufferSizes")]
+        public static extern int GetDisplayConfigBufferSizes(uint flags, out uint numPathArrayElements, out uint numModeInfoArrayElements);
+
+        /// <summary>
+        /// Retrieves the display paths that make up the current desktop.
+        /// </summary>
+        /// <param name="flags">The topology to query, such as <see cref="QDC_ONLY_ACTIVE_PATHS"/>.</param>
+        /// <param name="numPathArrayElements">On entry the array size, on return the number of paths written.</param>
+        /// <param name="pathArray">Receives the paths.</param>
+        /// <param name="numModeInfoArrayElements">On entry the array size, on return the number of modes written.</param>
+        /// <param name="modeInfoArray">Receives the modes.</param>
+        /// <param name="currentTopologyId">Reserved for database queries; pass zero.</param>
+        /// <returns>ERROR_SUCCESS (0) on success; otherwise, a Win32 error code.</returns>
+        /// <seealso href="https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-querydisplayconfig"/>
+        [DllImport("user32.dll", EntryPoint = "QueryDisplayConfig")]
+        public static extern int QueryDisplayConfig(
+            uint flags,
+            ref uint numPathArrayElements,
+            [Out] DISPLAYCONFIG_PATH_INFO[] pathArray,
+            ref uint numModeInfoArrayElements,
+            [Out] DISPLAYCONFIG_MODE_INFO[] modeInfoArray,
+            IntPtr currentTopologyId);
+
+        /// <summary>
+        /// Retrieves the GDI device name of a display path's source.
+        /// </summary>
+        /// <param name="requestPacket">The request, with its header filled in.</param>
+        /// <returns>ERROR_SUCCESS (0) on success; otherwise, a Win32 error code.</returns>
+        /// <seealso href="https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-displayconfiggetdeviceinfo"/>
+        [DllImport("user32.dll", EntryPoint = "DisplayConfigGetDeviceInfo")]
+        public static extern int DisplayConfigGetDeviceInfo(ref DISPLAYCONFIG_SOURCE_DEVICE_NAME requestPacket);
+
+        /// <summary>
+        /// Retrieves the name and device interface path of a display path's target.
+        /// </summary>
+        /// <param name="requestPacket">The request, with its header filled in.</param>
+        /// <returns>ERROR_SUCCESS (0) on success; otherwise, a Win32 error code.</returns>
+        /// <seealso href="https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-displayconfiggetdeviceinfo"/>
+        [DllImport("user32.dll", EntryPoint = "DisplayConfigGetDeviceInfo")]
+        public static extern int DisplayConfigGetDeviceInfo(ref DISPLAYCONFIG_TARGET_DEVICE_NAME requestPacket);
+
+        #endregion Display Configuration (CCD)
 
         #region Process Memory Management
 

--- a/OLED-Sleeper/UI/Helpers/MonitorTitleFormatter.cs
+++ b/OLED-Sleeper/UI/Helpers/MonitorTitleFormatter.cs
@@ -1,0 +1,25 @@
+using OLED_Sleeper.Features.MonitorInformation.Models;
+
+namespace OLED_Sleeper.UI.Helpers
+{
+    /// <summary>
+    /// Builds the title a monitor is shown under. This is a static helper class and does not hold any state.
+    /// </summary>
+    public static class MonitorTitleFormatter
+    {
+        /// <summary>
+        /// Titles a monitor the way Windows titles it: the display number, or the numbers of every panel
+        /// showing the surface when it is duplicated, such as <c>Monitor 1|2</c>.
+        /// </summary>
+        /// <param name="monitor">The monitor to title.</param>
+        /// <returns>The title, marked as the primary display where applicable.</returns>
+        public static string Format(MonitorInfo monitor)
+        {
+            string number = string.IsNullOrEmpty(monitor.TopologyLabel)
+                ? monitor.DisplayNumber.ToString()
+                : monitor.TopologyLabel;
+
+            return monitor.IsPrimary ? $"Monitor {number} (Primary)" : $"Monitor {number}";
+        }
+    }
+}

--- a/OLED-Sleeper/UI/ViewModels/MonitorConfigurationViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MonitorConfigurationViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using OLED_Sleeper.Features.MonitorBehavior.Models;
 using OLED_Sleeper.Features.MonitorInformation.Models;
 using OLED_Sleeper.Features.UserSettings.Models;
+using OLED_Sleeper.UI.Helpers;
 using OLED_Sleeper.UI.Models;
 using System.ComponentModel;
 
@@ -20,9 +21,10 @@ namespace OLED_Sleeper.UI.ViewModels
         #region Properties
 
         /// <summary>
-        /// The display title for the monitor, including primary indicator if applicable.
+        /// The display title for the monitor, including primary indicator if applicable. A duplicated surface
+        /// is titled the way Windows titles it, such as <c>Monitor 1|2</c>.
         /// </summary>
-        public string MonitorTitle => _monitorInfo.IsPrimary ? $"Monitor {_monitorInfo.DisplayNumber} (Primary)" : $"Monitor {_monitorInfo.DisplayNumber}";
+        public string MonitorTitle => MonitorTitleFormatter.Format(_monitorInfo);
 
         public string IdleValueError => this["IdleValue"];
 

--- a/OLED-Sleeper/UI/ViewModels/MonitorLayoutViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MonitorLayoutViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using OLED_Sleeper.Features.MonitorInformation.Models;
+using OLED_Sleeper.UI.Helpers;
 using System.Windows;
 using System.Windows.Media;
 
@@ -39,9 +40,10 @@ namespace OLED_Sleeper.UI.ViewModels
         public bool IsDirty => Configuration.IsDirty;
 
         /// <summary>
-        /// The display title for the monitor, including primary indicator if applicable.
+        /// The display title for the monitor, including primary indicator if applicable. A duplicated surface
+        /// is titled the way Windows titles it, such as <c>Monitor 1|2</c>.
         /// </summary>
-        public string MonitorTitle => _monitor.IsPrimary ? $"Monitor {_monitor.DisplayNumber} (Primary)" : $"Monitor {_monitor.DisplayNumber}";
+        public string MonitorTitle => MonitorTitleFormatter.Format(_monitor);
 
         /// <summary>
         /// The display number for the monitor.


### PR DESCRIPTION
Restores DDC/CI access and correct monitor identity when a panel is duplicated onto a second display.

* The display numbers in `Monitor 1|2` come from each panel's position in the active-path list. Windows documents no API for the numbers it shows, so this matches the reported setup and nothing else.
* `TopologyLabel` joins `HasSamePlacement`. Nothing else in a reading changes when a panel starts being duplicated, so without it the poll never resyncs and the title stays stale.
* Only the first responding panel is driven. Duplicate two DDC-capable monitors and one dims while the other stays lit; driving both needs a brightness record per panel rather than per hardware ID.
* `PHYSICAL_MONITOR` now marshals as Unicode. It was an ANSI 136-byte struct handed to dxva2 for the 264 bytes it writes, on every DDC call.
* `GetPhysicalMonitorsFromHMONITOR` fails with `0xC02625E6` unless the array size matches `GetNumberOfPhysicalMonitorsFromHMONITOR`. With two panels the capability probe reached neither, and every dim and undim was a no-op.
* Hardware IDs came from monitor child 0, which under duplication is the virtual display. `QueryDisplayConfig` names the target of the adapter's own path; the paths are read only when an adapter reports more than one child.
