### PR TITLE
feat: make the blackout brightness drop optional per monitor

### DIFF
--- a/OLED-Sleeper/Features/MonitorBehavior/Handlers/ApplyMonitorIdleBehaviorCommandHandler.cs
+++ b/OLED-Sleeper/Features/MonitorBehavior/Handlers/ApplyMonitorIdleBehaviorCommandHandler.cs
@@ -29,7 +29,7 @@ namespace OLED_Sleeper.Features.MonitorBehavior.Handlers
             switch (e.Settings.Behavior)
             {
                 case MonitorBehaviorType.Blackout:
-                    await _mediator.SendAsync(new ApplyBlackoutOverlayCommand { HardwareId = e.HardwareId });
+                    await _mediator.SendAsync(new ApplyBlackoutOverlayCommand { HardwareId = e.HardwareId, LowerBrightness = e.Settings.LowerBrightnessOnBlackout });
                     break;
                 case MonitorBehaviorType.Dim:
                     await _mediator.SendAsync(new ApplyDimCommand { HardwareId = e.HardwareId, DimLevel = (int)e.Settings.DimLevel });

--- a/OLED-Sleeper/Features/MonitorBlackout/Commands/ApplyBlackoutOverlayCommand.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Commands/ApplyBlackoutOverlayCommand.cs
@@ -13,5 +13,10 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Commands
         /// The unique hardware identifier of the target monitor.
         /// </summary>
         public required string HardwareId { get; init; }
+
+        /// <summary>
+        /// Whether to also set the monitor's hardware brightness to zero. True when unset.
+        /// </summary>
+        public bool LowerBrightness { get; init; } = true;
     }
 }

--- a/OLED-Sleeper/Features/MonitorBlackout/Handlers/ApplyBlackoutOverlayCommandHandler.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Handlers/ApplyBlackoutOverlayCommandHandler.cs
@@ -11,7 +11,8 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Handlers
     /// <summary>
     /// Handles the execution of the <see cref="ApplyBlackoutOverlayCommand"/>.
     /// This class contains the business logic for applying the blackout effect to a monitor,
-    /// which includes showing a software overlay and setting the hardware brightness to zero if supported.
+    /// which includes showing a software overlay and, when the command asks for it, setting the hardware
+    /// brightness to zero if supported.
     /// </summary>
     public class ApplyBlackoutOverlayCommandHandler : ICommandHandler<ApplyBlackoutOverlayCommand>
     {
@@ -31,7 +32,7 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Handlers
 
         /// <summary>
         /// Executes the blackout logic asynchronously based on the command's data.
-        /// It shows a blackout overlay and, if the monitor supports DDC/CI,
+        /// It shows a blackout overlay and, if the command asks for it and the monitor supports DDC/CI,
         /// it simultaneously dims the monitor's brightness to 0.
         /// Exceptions are caught and logged to avoid silent failures.
         /// </summary>
@@ -52,7 +53,12 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Handlers
 
                 var showOverlayTask = _monitorBlackoutService.ShowBlackoutOverlayAsync(monitorInfo.HardwareId, monitorInfo.Bounds);
 
-                if (monitorInfo.Capabilities?.IsSupported == true)
+                if (!command.LowerBrightness)
+                {
+                    Log.Information("Blackout for monitor {HardwareId} leaves hardware brightness untouched by user setting.", monitorInfo.HardwareId);
+                    await showOverlayTask;
+                }
+                else if (monitorInfo.Capabilities?.IsSupported == true)
                 {
                     Log.Information("Monitor {HardwareId} supports DDC/CI. Setting brightness to 0 for blackout.", monitorInfo.HardwareId);
                     var dimTask = _monitorDimmingService.DimMonitorAsync(monitorInfo.HardwareId, 0);

--- a/OLED-Sleeper/Features/UserSettings/Models/MonitorSettings.cs
+++ b/OLED-Sleeper/Features/UserSettings/Models/MonitorSettings.cs
@@ -29,6 +29,12 @@ namespace OLED_Sleeper.Features.UserSettings.Models
         public double DimLevel { get; set; } = 15;
 
         /// <summary>
+        /// Gets or sets a value indicating whether a blackout also sets the monitor's hardware brightness to zero.
+        /// Absent from a settings file written before this option existed, which leaves it at its default of true.
+        /// </summary>
+        public bool LowerBrightnessOnBlackout { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the idle timeout value (unit specified by <see cref="IdleUnit"/>).
         /// </summary>
         public int? IdleValue { get; set; } = 30;

--- a/OLED-Sleeper/UI/ViewModels/MonitorConfigurationViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MonitorConfigurationViewModel.cs
@@ -92,6 +92,8 @@ namespace OLED_Sleeper.UI.ViewModels
                 if (_behavior == MonitorBehaviorType.Blackout) { DimLevel = 0; }
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(IsDimSliderEnabled));
+                OnPropertyChanged(nameof(IsLowerBrightnessOptionEnabled));
+                OnPropertyChanged(nameof(LowerBrightnessTooltip));
                 OnPropertyChanged(nameof(BehaviorError));
                 UpdateDirtyState();
             }
@@ -120,6 +122,53 @@ namespace OLED_Sleeper.UI.ViewModels
         /// Returns true if the dim slider should be enabled (only for Dim behavior).
         /// </summary>
         public bool IsDimSliderEnabled => Behavior == MonitorBehaviorType.Dim;
+
+        // --- LowerBrightnessOnBlackout ---
+        private bool _lowerBrightnessOnBlackout;
+
+        private bool _initialLowerBrightnessOnBlackout;
+
+        /// <summary>
+        /// Gets or sets whether a blackout also sets this monitor's hardware brightness to zero.
+        /// Always false on a monitor without DDC/CI support.
+        /// </summary>
+        public bool LowerBrightnessOnBlackout
+        {
+            get => _lowerBrightnessOnBlackout;
+            set
+            {
+                _lowerBrightnessOnBlackout = value;
+                OnPropertyChanged();
+                UpdateDirtyState();
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the lower-brightness option should be enabled (only for Blackout behavior on a monitor that supports DDC/CI).
+        /// </summary>
+        public bool IsLowerBrightnessOptionEnabled => Behavior == MonitorBehaviorType.Blackout && IsDimBehaviorEnabled;
+
+        /// <summary>
+        /// Gets the tooltip for the lower-brightness option, prefixed with the reason when the option is disabled.
+        /// </summary>
+        public string LowerBrightnessTooltip
+        {
+            get
+            {
+                string baseTooltip = "Takes the monitor's own brightness down to zero\n" +
+                                     "as well as covering the screen with the black overlay.\n\n" +
+                                     "Useful on non-OLED displays, where the backlight\n" +
+                                     "stays lit behind the black overlay.";
+
+                if (!IsDimBehaviorEnabled)
+                    return "THE SELECTED MONITOR DOES NOT SUPPORT DIMMING.\n\n" + baseTooltip;
+
+                if (Behavior != MonitorBehaviorType.Blackout)
+                    return "AVAILABLE ONLY WHEN BLACKOUT IS SELECTED.\n\n" + baseTooltip;
+
+                return baseTooltip;
+            }
+        }
 
         // --- Idle Timer ---
         /// <summary>
@@ -241,6 +290,7 @@ namespace OLED_Sleeper.UI.ViewModels
             IsDirty = IsManaged != _initialIsManaged ||
                        Behavior != _initialBehavior ||
                        Math.Abs(DimLevel - _initialDimLevel) > epsilon ||
+                       LowerBrightnessOnBlackout != _initialLowerBrightnessOnBlackout ||
                        IdleValue != _initialIdleValue ||
                        SelectedTimeUnit != _initialSelectedTimeUnit ||
                        IsActiveOnInput != _initialIsActiveOnInput ||
@@ -258,6 +308,7 @@ namespace OLED_Sleeper.UI.ViewModels
             _initialIsManaged = IsManaged;
             _initialBehavior = Behavior;
             _initialDimLevel = DimLevel;
+            _initialLowerBrightnessOnBlackout = LowerBrightnessOnBlackout;
             _initialIdleValue = IdleValue;
             _initialSelectedTimeUnit = SelectedTimeUnit;
             _initialIsActiveOnInput = IsActiveOnInput;
@@ -275,6 +326,7 @@ namespace OLED_Sleeper.UI.ViewModels
             IsManaged = settings.IsManaged;
             Behavior = settings.Behavior;
             DimLevel = settings.DimLevel;
+            LowerBrightnessOnBlackout = settings.LowerBrightnessOnBlackout && IsDimBehaviorEnabled;
             IdleValue = settings.IdleValue;
             SelectedTimeUnit = settings.IdleUnit;
             IsActiveOnInput = settings.IsActiveOnInput;
@@ -294,6 +346,7 @@ namespace OLED_Sleeper.UI.ViewModels
                 IsManaged = IsManaged,
                 Behavior = Behavior,
                 DimLevel = DimLevel,
+                LowerBrightnessOnBlackout = LowerBrightnessOnBlackout,
                 IdleValue = IdleValue,
                 IdleUnit = SelectedTimeUnit,
                 IsActiveOnInput = IsActiveOnInput,

--- a/OLED-Sleeper/UI/Views/MonitorConfigurationView.xaml
+++ b/OLED-Sleeper/UI/Views/MonitorConfigurationView.xaml
@@ -328,6 +328,12 @@
                                 ToolTip="{Binding DimBehaviorTooltip}"
                                 ToolTipService.InitialShowDelay="200" />
                         </StackPanel>
+                        <CheckBox Content="Also set brightness to zero" Style="{StaticResource ModernCheckBox}" Margin="0,12,0,0" FontSize="13"
+                            IsChecked="{Binding LowerBrightnessOnBlackout, UpdateSourceTrigger=PropertyChanged}"
+                            IsEnabled="{Binding IsLowerBrightnessOptionEnabled}"
+                            ToolTip="{Binding LowerBrightnessTooltip}"
+                            ToolTipService.InitialShowDelay="200"
+                            ToolTipService.ShowOnDisabled="True" />
                     </StackPanel>
 
                     <!-- Brightness Level Section -->


### PR DESCRIPTION
Adds a per-monitor option that turns off the DDC/CI brightness write a blackout performs, leaving the overlay to cover the screen on its own.

* Stored as `LowerBrightnessOnBlackout`, default true. A `settings.json` written before this option lacks the property and keeps that default, so `SchemaVersion` is unchanged.
* The option reads as off on a monitor without DDC/CI, and a save while it is off persists it that way.
* The checkbox sits under the behavior radios, disabled outside Blackout, with the reason in caps at the top of its tooltip.
