### PR TITLE
fix: make the release pipeline build from a clean checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # MinVer derives the version from the nearest v* tag, so it needs the full history.
           fetch-depth: 0
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.0.x'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # MinVer derives the version from the nearest v* tag, so it needs the full history.
           fetch-depth: 0
@@ -42,7 +42,7 @@ jobs:
           Write-Host "$env:GITHUB_REF_NAME is on master."
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.0.x'
 
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload the test build
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: oled-sleeper-${{ steps.version.outputs.version }}
           path: |


### PR DESCRIPTION
Two fixes to the release pipeline, both found while cutting `v2.2.0`.

## `build.ps1` fails on a clean checkout

The `v2.2.0` release run died at its first step:

```
error MSB4057: The target "MinVer" does not exist in the project.
```

`Reading version` is the first thing `build.ps1` does, and `dotnet msbuild -t:MinVer` does not restore. MinVer's targets are imported from `obj/OLED-Sleeper.csproj.nuget.g.targets`, which only exists after a restore, so on a clean checkout the target genuinely is not there yet. A local run always worked because `obj/` was already populated from earlier builds; the later `dotnet publish` would have restored, but the version read happens before it.

`Get-BuildVersion` now restores first. Reproduced in a clean `git worktree` (same MSB4057), and confirmed the restore makes the version read succeed.

This is the first release to go through `build.ps1`, which is why earlier tags were unaffected.

## Actions on the deprecated Node.js 20 runtime

GitHub warns that `actions/checkout@v4` and `actions/setup-dotnet@v4` target Node.js 20 and are being forced onto Node.js 24.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v4` | `v7` |
| `actions/setup-dotnet` | `v4` | `v6` |
| `actions/upload-artifact` | `v4` | `v7` |

`upload-artifact` was not named in the warning only because its step is gated on `workflow_dispatch` and did not run; it carried the same deprecated runtime.

The major bumps are ESM and dependency churn. The one behavioural change is checkout v7 refusing to check out fork PRs under `pull_request_target` and `workflow_run`, neither of which this repo uses. All three majors require runner 2.327.1 or newer, which `windows-latest` satisfies.
