### PR TITLE
fix: restore the project before reading the version so a clean checkout can build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -88,6 +88,10 @@ Then re-run this script, or pass the path directly:
     Reads the version MinVer derives from the nearest v* tag.
 #>
 function Get-BuildVersion {
+    # MinVer's targets arrive with the package, so a clean checkout has to restore before the target exists.
+    & dotnet restore $projectPath --nologo | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw 'Restore failed while preparing to read the version.' }
+
     $output = & dotnet msbuild $projectPath -t:MinVer -getProperty:Version -v:quiet -nologo
     if ($LASTEXITCODE -ne 0) { throw 'Could not read the version from the project.' }
 


### PR DESCRIPTION
Restores the project before reading the version, so `build.ps1` works on a clean checkout.

* The `v2.2.0` run failed with `MSB4057: The target "MinVer" does not exist`. MinVer's targets are imported from `obj/OLED-Sleeper.csproj.nuget.g.targets`, which a clean checkout has not written yet.
* `Reading version` is the first step, ahead of the `dotnet publish` that would have restored. Local runs passed because `obj/` was already populated.
* Reproduced in a clean `git worktree` for the identical MSB4057, then confirmed the restore makes the version read succeed.
