### PR TITLE
fix: restore the project before reading the version so a clean checkout can build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -88,6 +88,10 @@ Then re-run this script, or pass the path directly:
     Reads the version MinVer derives from the nearest v* tag.
 #>
 function Get-BuildVersion {
+    # MinVer's targets arrive with the package, so a clean checkout has to restore before the target exists.
+    & dotnet restore $projectPath --nologo | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw 'Restore failed while preparing to read the version.' }
+
     $output = & dotnet msbuild $projectPath -t:MinVer -getProperty:Version -v:quiet -nologo
     if ($LASTEXITCODE -ne 0) { throw 'Could not read the version from the project.' }
 


### PR DESCRIPTION
Brings the clean-checkout version fix onto `master` so `v2.2.0` can be released.

* The `v2.2.0` tag has to be re-pointed after this merges. It currently sits on `935d88f`, which predates the fix, and its release run failed before any release object was created.
* `build.ps1` now restores before reading the version. Without it the tagged run fails at the first step with `MSB4057: The target "MinVer" does not exist`.
