### PR TITLE
fix: wrap the portable zip contents in an OLED-Sleeper folder

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -169,14 +169,14 @@ if (-not (Test-Path -LiteralPath $setupPath)) { throw "The installer was not pro
 
 if (-not $SkipPortable) {
     Write-Step 'Publishing the portable build'
-    $portableX64 = Join-Path $stagingDirectory 'portable'
+    $portableX64 = Join-Path $stagingDirectory 'portable\OLED-Sleeper'
     Publish-Payload -Runtime 'win-x64' -Destination $portableX64 -Portable
 
     Write-Step 'Zipping the portable build'
     $zipPath = Join-Path $OutputDirectory "OLED-Sleeper-$version-Portable-x64.zip"
     if (Test-Path -LiteralPath $zipPath) { Remove-Item -LiteralPath $zipPath -Force }
-    # The exe sits at the zip root, so extracting anywhere gives a working folder.
-    Compress-Archive -Path (Join-Path $portableX64 '*') -DestinationPath $zipPath
+    # The zip carries its own OLED-Sleeper folder, so extracting it never scatters files loose.
+    Compress-Archive -Path $portableX64 -DestinationPath $zipPath
 }
 
 Write-Step 'Writing checksums'


### PR DESCRIPTION
The portable zip now extracts into an `OLED-Sleeper` folder instead of scattering the executable and its files wherever it was unzipped.

* The portable payload publishes to `artifacts/publish/portable/OLED-Sleeper` and `Compress-Archive` is handed that folder rather than its contents, which makes the folder the zip root.
* Anyone extracting over an existing portable copy gets the new folder alongside it, so their `Data\` stays where it is.
