### PR TITLE
fix: default the blackout brightness drop to off

### DIFF
--- a/OLED-Sleeper/Features/UserSettings/Models/MonitorSettings.cs
+++ b/OLED-Sleeper/Features/UserSettings/Models/MonitorSettings.cs
@@ -30,9 +30,9 @@ namespace OLED_Sleeper.Features.UserSettings.Models
 
         /// <summary>
         /// Gets or sets a value indicating whether a blackout also sets the monitor's hardware brightness to zero.
-        /// Absent from a settings file written before this option existed, which leaves it at its default of true.
+        /// Absent from a settings file written before this option existed, which leaves it at its default of false.
         /// </summary>
-        public bool LowerBrightnessOnBlackout { get; set; } = true;
+        public bool LowerBrightnessOnBlackout { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the idle timeout value (unit specified by <see cref="IdleUnit"/>).


### PR DESCRIPTION
A blackout no longer drops the monitor's hardware brightness to zero unless the option is turned on for that monitor.

* `LowerBrightnessOnBlackout` defaults to `false`, so a settings file written before the option existed now reads as off rather than on, which is the behaviour change for anyone upgrading.
* A monitor that saved the option explicitly keeps whatever it saved. Installing resets `settings.json`, so an installed upgrade lands on the new default either way.
