### PR TITLE
release: bring the blackout brightness default and the tray exit prompt onto master

### DIFF
--- a/OLED-Sleeper.Tests/TestDoubles/ImmediateDispatcher.cs
+++ b/OLED-Sleeper.Tests/TestDoubles/ImmediateDispatcher.cs
@@ -26,6 +26,11 @@ namespace OLED_Sleeper.Tests.TestDoubles
         public int InvokeAsyncCount { get; private set; }
 
         /// <summary>
+        /// How many actions have been run through <see cref="InvokeAfterInputAsync"/>.
+        /// </summary>
+        public int InvokeAfterInputCount { get; private set; }
+
+        /// <summary>
         /// Whether the caller counts as being on the UI thread. Starts true; set it to false to make a
         /// class under test take its marshalling branch. Reads true while an action is running.
         /// </summary>
@@ -42,6 +47,14 @@ namespace OLED_Sleeper.Tests.TestDoubles
         public Task InvokeAsync(Action action)
         {
             InvokeAsyncCount++;
+            Run(action);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public Task InvokeAfterInputAsync(Action action)
+        {
+            InvokeAfterInputCount++;
             Run(action);
             return Task.CompletedTask;
         }

--- a/OLED-Sleeper.Tests/UI/Services/UnsavedSettingsServiceTests.cs
+++ b/OLED-Sleeper.Tests/UI/Services/UnsavedSettingsServiceTests.cs
@@ -1,0 +1,155 @@
+using Moq;
+using OLED_Sleeper.UI.Services;
+using OLED_Sleeper.UI.Services.Interfaces;
+using System.Windows;
+
+namespace OLED_Sleeper.Tests.UI.Services
+{
+    public class UnsavedSettingsServiceTests
+    {
+        private readonly Mock<IUnsavedSettings> _unsavedSettingsMock;
+        private readonly Mock<IDialogService> _dialogServiceMock;
+        private readonly UnsavedSettingsService _service;
+
+        public UnsavedSettingsServiceTests()
+        {
+            _unsavedSettingsMock = new Mock<IUnsavedSettings>();
+            _dialogServiceMock = new Mock<IDialogService>();
+
+            _unsavedSettingsMock.Setup(x => x.IsDirty).Returns(true);
+            _unsavedSettingsMock.Setup(x => x.TrySaveChanges()).Returns(true);
+
+            _service = new UnsavedSettingsService(_unsavedSettingsMock.Object, _dialogServiceMock.Object);
+        }
+
+        [Fact]
+        public void ConfirmExit_WhenNothingIsDirty_GoesAheadWithoutAsking()
+        {
+            // Arrange
+            _unsavedSettingsMock.Setup(x => x.IsDirty).Returns(false);
+
+            // Act
+            var proceed = _service.ConfirmExit();
+
+            // Assert
+            Assert.True(proceed);
+            _dialogServiceMock.Verify(x => x.AskYesNoCancel(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            _unsavedSettingsMock.Verify(x => x.TrySaveChanges(), Times.Never);
+            _unsavedSettingsMock.Verify(x => x.DiscardChanges(), Times.Never);
+        }
+
+        [Fact]
+        public void ConfirmExit_WhenUserCancels_StopsWithoutSavingOrDiscarding()
+        {
+            // Arrange
+            SetupAnswer(MessageBoxResult.Cancel);
+
+            // Act
+            var proceed = _service.ConfirmExit();
+
+            // Assert
+            Assert.False(proceed);
+            _unsavedSettingsMock.Verify(x => x.TrySaveChanges(), Times.Never);
+            _unsavedSettingsMock.Verify(x => x.DiscardChanges(), Times.Never);
+        }
+
+        [Fact]
+        public void ConfirmExit_WhenUserSaves_GoesAheadAndKeepsTheChanges()
+        {
+            // Arrange
+            SetupAnswer(MessageBoxResult.Yes);
+
+            // Act
+            var proceed = _service.ConfirmExit();
+
+            // Assert
+            Assert.True(proceed);
+            _unsavedSettingsMock.Verify(x => x.TrySaveChanges(), Times.Once);
+            _unsavedSettingsMock.Verify(x => x.DiscardChanges(), Times.Never);
+        }
+
+        [Fact]
+        public void ConfirmExit_WhenTheSaveIsRejected_Stops()
+        {
+            // Arrange
+            SetupAnswer(MessageBoxResult.Yes);
+            _unsavedSettingsMock.Setup(x => x.TrySaveChanges()).Returns(false);
+
+            // Act
+            var proceed = _service.ConfirmExit();
+
+            // Assert
+            Assert.False(proceed);
+            _unsavedSettingsMock.Verify(x => x.DiscardChanges(), Times.Never);
+        }
+
+        [Fact]
+        public void ConfirmExit_WhenUserDeclinesToSave_DiscardsAndGoesAhead()
+        {
+            // Arrange
+            SetupAnswer(MessageBoxResult.No);
+
+            // Act
+            var proceed = _service.ConfirmExit();
+
+            // Assert
+            Assert.True(proceed);
+            _unsavedSettingsMock.Verify(x => x.DiscardChanges(), Times.Once);
+            _unsavedSettingsMock.Verify(x => x.TrySaveChanges(), Times.Never);
+        }
+
+        [Fact]
+        public void ConfirmHide_WhenUserDeclinesToSave_DiscardsAndGoesAhead()
+        {
+            // Arrange
+            SetupAnswer(MessageBoxResult.No);
+
+            // Act
+            var proceed = _service.ConfirmHide();
+
+            // Assert
+            Assert.True(proceed);
+            _unsavedSettingsMock.Verify(x => x.DiscardChanges(), Times.Once);
+        }
+
+        [Fact]
+        public void ConfirmHide_WhenUserCancels_Stops()
+        {
+            // Arrange
+            SetupAnswer(MessageBoxResult.Cancel);
+
+            // Act
+            var proceed = _service.ConfirmHide();
+
+            // Assert
+            Assert.False(proceed);
+            _unsavedSettingsMock.Verify(x => x.DiscardChanges(), Times.Never);
+        }
+
+        [Fact]
+        public void EachCaller_AsksAboutItsOwnAction()
+        {
+            // Arrange
+            SetupAnswer(MessageBoxResult.No);
+
+            // Act
+            _service.ConfirmHide();
+            _service.ConfirmExit();
+
+            // Assert
+            _dialogServiceMock.Verify(x => x.AskYesNoCancel(It.Is<string>(m => m.Contains("hiding the window")), "Unsaved Changes"), Times.Once);
+            _dialogServiceMock.Verify(x => x.AskYesNoCancel(It.Is<string>(m => m.Contains("exiting")), "Unsaved Changes"), Times.Once);
+        }
+
+        /// <summary>
+        /// Makes the unsaved-changes prompt return the supplied answer.
+        /// </summary>
+        /// <param name="answer">The answer the prompt should return.</param>
+        private void SetupAnswer(MessageBoxResult answer)
+        {
+            _dialogServiceMock
+                .Setup(x => x.AskYesNoCancel(It.IsAny<string>(), "Unsaved Changes"))
+                .Returns(answer);
+        }
+    }
+}

--- a/OLED-Sleeper.Tests/UI/ViewModels/MainViewModelTests.cs
+++ b/OLED-Sleeper.Tests/UI/ViewModels/MainViewModelTests.cs
@@ -14,8 +14,6 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
     {
         private readonly Mock<IWorkspaceService> _workspaceServiceMock;
         private readonly Mock<IMonitorSettingsSaveService> _saveServiceMock;
-        private readonly Mock<IMainWindowAccessor> _mainWindowAccessorMock;
-        private readonly Mock<IDialogService> _dialogServiceMock;
         private readonly ImmediateDispatcher _dispatcher;
         private readonly MainViewModel _viewModel;
 
@@ -23,8 +21,6 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         {
             _workspaceServiceMock = new Mock<IWorkspaceService>();
             _saveServiceMock = new Mock<IMonitorSettingsSaveService>();
-            _mainWindowAccessorMock = new Mock<IMainWindowAccessor>();
-            _dialogServiceMock = new Mock<IDialogService>();
             _dispatcher = new ImmediateDispatcher();
 
             SetupWorkspace();
@@ -33,9 +29,7 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
             _viewModel = new MainViewModel(
                 _workspaceServiceMock.Object,
                 _saveServiceMock.Object,
-                _dispatcher,
-                _mainWindowAccessorMock.Object,
-                _dialogServiceMock.Object);
+                _dispatcher);
         }
 
         [Fact]
@@ -315,83 +309,57 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
         }
 
         [Fact]
-        public void DiscardChangesCommand_RefreshesWorkspacePreservingSelection()
+        public void DiscardChangesCommand_RevertsEachMonitorAndKeepsTheSelection()
         {
             // Arrange
             var monitor = CreateMonitor("MON-1");
             LoadMonitors(monitor);
             _viewModel.SelectMonitorCommand.Execute(monitor);
-            var rebuilt = CreateMonitor("MON-1");
-            SetupWorkspace(rebuilt);
+            var savedDimLevel = monitor.Configuration.DimLevel;
+            monitor.Configuration.DimLevel = 50;
 
             // Act
             _viewModel.DiscardChangesCommand.Execute(null);
 
             // Assert
-            _workspaceServiceMock.Verify(x => x.RefreshWorkspaceAsync(800, 600), Times.Once);
-            Assert.Same(rebuilt, _viewModel.SelectedMonitor);
+            Assert.Equal(savedDimLevel, monitor.Configuration.DimLevel);
+            Assert.False(_viewModel.IsDirty);
+            Assert.Same(monitor, _viewModel.SelectedMonitor);
+            _workspaceServiceMock.Verify(x => x.RefreshWorkspaceAsync(It.IsAny<double>(), It.IsAny<double>()), Times.Never);
         }
 
         [Fact]
-        public void OnWindowClosing_WhenNotDirty_HidesMainWindowAndReturnsFalse()
-        {
-            // Act
-            var shouldClose = _viewModel.OnWindowClosing();
-
-            // Assert
-            Assert.False(shouldClose);
-            _mainWindowAccessorMock.Verify(x => x.HideMainWindow(), Times.Once);
-            _dialogServiceMock.Verify(x => x.AskYesNoCancel(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-        }
-
-        [Fact]
-        public void OnWindowClosing_WhenDirtyAndUserCancels_KeepsWindowVisible()
-        {
-            // Arrange
-            _viewModel.IsDirty = true;
-            SetupUnsavedChangesAnswer(MessageBoxResult.Cancel);
-
-            // Act
-            var shouldClose = _viewModel.OnWindowClosing();
-
-            // Assert
-            Assert.False(shouldClose);
-            _mainWindowAccessorMock.Verify(x => x.HideMainWindow(), Times.Never);
-            _saveServiceMock.Verify(x => x.TrySave(It.IsAny<IReadOnlyList<MonitorLayoutViewModel>>()), Times.Never);
-        }
-
-        [Fact]
-        public void OnWindowClosing_WhenDirtyAndUserSaves_SavesThenHides()
+        public void TrySaveChanges_WhenSaveSucceeds_ClearsDirtyStateWithoutTouchingTheButton()
         {
             // Arrange
             var monitor = CreateMonitor("MON-1");
             LoadMonitors(monitor);
             monitor.Configuration.DimLevel = 50;
-            SetupUnsavedChangesAnswer(MessageBoxResult.Yes);
 
             // Act
-            var shouldClose = _viewModel.OnWindowClosing();
+            var saved = _viewModel.TrySaveChanges();
 
             // Assert
-            Assert.False(shouldClose);
-            _saveServiceMock.Verify(x => x.TrySave(It.IsAny<IReadOnlyList<MonitorLayoutViewModel>>()), Times.Once);
-            _mainWindowAccessorMock.Verify(x => x.HideMainWindow(), Times.Once);
+            Assert.True(saved);
+            Assert.False(_viewModel.IsDirty);
+            Assert.Equal("Save Settings", _viewModel.SaveButtonText);
         }
 
         [Fact]
-        public void OnWindowClosing_WhenDirtyAndUserDiscards_HidesWithoutSaving()
+        public void TrySaveChanges_WhenSaveIsRejected_ReportsFailureAndKeepsDirtyState()
         {
             // Arrange
-            _viewModel.IsDirty = true;
-            SetupUnsavedChangesAnswer(MessageBoxResult.No);
+            var monitor = CreateMonitor("MON-1");
+            LoadMonitors(monitor);
+            monitor.Configuration.DimLevel = 50;
+            SetupSaveOutcome(false);
 
             // Act
-            var shouldClose = _viewModel.OnWindowClosing();
+            var saved = _viewModel.TrySaveChanges();
 
             // Assert
-            Assert.False(shouldClose);
-            _saveServiceMock.Verify(x => x.TrySave(It.IsAny<IReadOnlyList<MonitorLayoutViewModel>>()), Times.Never);
-            _mainWindowAccessorMock.Verify(x => x.HideMainWindow(), Times.Once);
+            Assert.False(saved);
+            Assert.True(_viewModel.IsDirty);
         }
 
         [Fact]
@@ -518,17 +486,6 @@ namespace OLED_Sleeper.Tests.UI.ViewModels
 
                     return true;
                 });
-        }
-
-        /// <summary>
-        /// Makes the unsaved-changes prompt return the supplied answer.
-        /// </summary>
-        /// <param name="answer">The answer the prompt should return.</param>
-        private void SetupUnsavedChangesAnswer(MessageBoxResult answer)
-        {
-            _dialogServiceMock
-                .Setup(x => x.AskYesNoCancel(It.IsAny<string>(), "Unsaved Changes"))
-                .Returns(answer);
         }
 
         /// <summary>

--- a/OLED-Sleeper/Features/UserSettings/Models/MonitorSettings.cs
+++ b/OLED-Sleeper/Features/UserSettings/Models/MonitorSettings.cs
@@ -30,9 +30,9 @@ namespace OLED_Sleeper.Features.UserSettings.Models
 
         /// <summary>
         /// Gets or sets a value indicating whether a blackout also sets the monitor's hardware brightness to zero.
-        /// Absent from a settings file written before this option existed, which leaves it at its default of true.
+        /// Absent from a settings file written before this option existed, which leaves it at its default of false.
         /// </summary>
-        public bool LowerBrightnessOnBlackout { get; set; } = true;
+        public bool LowerBrightnessOnBlackout { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the idle timeout value (unit specified by <see cref="IdleUnit"/>).

--- a/OLED-Sleeper/Infrastructure/Hosting/ApplicationBootstrapper.cs
+++ b/OLED-Sleeper/Infrastructure/Hosting/ApplicationBootstrapper.cs
@@ -42,6 +42,7 @@ namespace OLED_Sleeper.Infrastructure.Hosting
         private IMainWindowService? _mainWindowService;
         private IApplicationInstanceManager? _instanceManager;
         private IApplicationOrchestrator? _orchestrator;
+        private IUnsavedSettingsService? _unsavedSettingsService;
         private bool _isExiting = false;
 
         /// <summary>
@@ -143,11 +144,24 @@ namespace OLED_Sleeper.Infrastructure.Hosting
         private void SetupTrayIconService()
         {
             if (_serviceProvider == null) return;
+            _unsavedSettingsService = _serviceProvider.GetRequiredService<IUnsavedSettingsService>();
             _trayIconService = _serviceProvider.GetRequiredService<ITrayIconService>();
             _trayIconService.Initialize(
                 () => _mainWindowService?.ShowMainWindow(),
-                () => ShutdownApp()
+                RequestExit
             );
+        }
+
+        /// <summary>
+        /// Handles the tray menu's Exit. Unsaved settings are answered for first, and the exit is abandoned
+        /// when the user cancels. Only this path asks; <c>OnExit</c> and <c>SessionEnding</c> shut down
+        /// without a prompt.
+        /// </summary>
+        private void RequestExit()
+        {
+            if (_unsavedSettingsService?.ConfirmExit() == false) return;
+
+            ShutdownApp();
         }
 
         /// <summary>
@@ -159,13 +173,16 @@ namespace OLED_Sleeper.Infrastructure.Hosting
         }
 
         /// <summary>
-        /// Stops the orchestrator, disposes the tray icon and the instance manager, flushes the log, and exits.
-        /// A second instance has no orchestrator and restores nothing.
+        /// Tells the main window the application is exiting, stops the orchestrator, disposes the tray icon
+        /// and the instance manager, flushes the log, and exits. A second instance has no orchestrator and
+        /// restores nothing.
         /// </summary>
         public void ShutdownApp()
         {
             if (_isExiting) return; // Prevent re-entrancy
             _isExiting = true;
+
+            _mainWindowService?.PrepareForShutdown();
 
             StopOrchestrator();
 

--- a/OLED-Sleeper/Infrastructure/Hosting/ApplicationBootstrapper.cs
+++ b/OLED-Sleeper/Infrastructure/Hosting/ApplicationBootstrapper.cs
@@ -36,6 +36,11 @@ namespace OLED_Sleeper.Infrastructure.Hosting
         /// </summary>
         private readonly IApplicationShutdown _applicationShutdown = new ApplicationShutdown();
 
+        /// <summary>
+        /// Reaches the UI thread. Created here for the same reason as <see cref="_applicationShutdown"/>.
+        /// </summary>
+        private readonly IDispatcher _dispatcher = new ApplicationDispatcher();
+
         private IStorageRoot? _storageRoot;
         private IServiceProvider? _serviceProvider;
         private ITrayIconService? _trayIconService;
@@ -104,7 +109,7 @@ namespace OLED_Sleeper.Infrastructure.Hosting
         /// </summary>
         private void InitializeInstanceManager()
         {
-            _instanceManager = new ApplicationInstanceManager(new ApplicationDispatcher(), _applicationShutdown);
+            _instanceManager = new ApplicationInstanceManager(_dispatcher, _applicationShutdown);
             _instanceManager.Initialize();
         }
 
@@ -153,13 +158,22 @@ namespace OLED_Sleeper.Infrastructure.Hosting
         }
 
         /// <summary>
-        /// Handles the tray menu's Exit. Unsaved settings are answered for first, and the exit is abandoned
-        /// when the user cancels. Only this path asks; <c>OnExit</c> and <c>SessionEnding</c> shut down
-        /// without a prompt.
+        /// Handles the tray menu's Exit. The work is queued behind the menu's own input, so the click that
+        /// picked Exit cannot answer the prompt that follows it.
         /// </summary>
-        private void RequestExit()
+        private void RequestExit() => _ = _dispatcher.InvokeAfterInputAsync(ConfirmAndShutdown);
+
+        /// <summary>
+        /// Shuts down unless the user cancels over unsaved settings. Only the tray exit asks; <c>OnExit</c>
+        /// and <c>SessionEnding</c> shut down without a prompt.
+        /// </summary>
+        private void ConfirmAndShutdown()
         {
-            if (_unsavedSettingsService?.ConfirmExit() == false) return;
+            if (_unsavedSettingsService?.ConfirmExit() == false)
+            {
+                Log.Information("Exit cancelled. Unsaved settings were kept.");
+                return;
+            }
 
             ShutdownApp();
         }

--- a/OLED-Sleeper/Infrastructure/Hosting/ApplicationBootstrapper.cs
+++ b/OLED-Sleeper/Infrastructure/Hosting/ApplicationBootstrapper.cs
@@ -98,7 +98,7 @@ namespace OLED_Sleeper.Infrastructure.Hosting
                 ? "Move the OLED Sleeper folder somewhere you can write to, such as your Desktop, and start it again."
                 : "Check that your user profile is accessible and start OLED Sleeper again.";
 
-            new MessageBoxDialogService().ShowError($"{error}{Environment.NewLine}{Environment.NewLine}{guidance}", StorageErrorCaption);
+            new MessageBoxDialogService(new MainWindowAccessor()).ShowError($"{error}{Environment.NewLine}{Environment.NewLine}{guidance}", StorageErrorCaption);
             _applicationShutdown.Shutdown();
             return false;
         }

--- a/OLED-Sleeper/Infrastructure/Hosting/ServiceConfigurator.cs
+++ b/OLED-Sleeper/Infrastructure/Hosting/ServiceConfigurator.cs
@@ -88,6 +88,8 @@ namespace OLED_Sleeper.Infrastructure.Hosting
             services.AddSingleton<ITrayIconService, TrayIconService>();
             services.AddSingleton<IMainWindowService, MainWindowService>();
             services.AddSingleton<IDialogService, MessageBoxDialogService>();
+            services.AddSingleton<IUnsavedSettings>(sp => sp.GetRequiredService<MainViewModel>());
+            services.AddSingleton<IUnsavedSettingsService, UnsavedSettingsService>();
             services.AddSingleton<IMonitorSettingsSaveService, MonitorSettingsSaveService>();
 
             return services.BuildServiceProvider();

--- a/OLED-Sleeper/Infrastructure/Runtime/ApplicationDispatcher.cs
+++ b/OLED-Sleeper/Infrastructure/Runtime/ApplicationDispatcher.cs
@@ -1,6 +1,7 @@
 using OLED_Sleeper.Infrastructure.Runtime.Interfaces;
 using System.Diagnostics.CodeAnalysis;
 using System.Windows;
+using System.Windows.Threading;
 
 namespace OLED_Sleeper.Infrastructure.Runtime
 {
@@ -19,5 +20,9 @@ namespace OLED_Sleeper.Infrastructure.Runtime
         /// <inheritdoc />
         public async Task InvokeAsync(Action action) =>
             await Application.Current.Dispatcher.InvokeAsync(action);
+
+        /// <inheritdoc />
+        public async Task InvokeAfterInputAsync(Action action) =>
+            await Application.Current.Dispatcher.InvokeAsync(action, DispatcherPriority.Background);
     }
 }

--- a/OLED-Sleeper/Infrastructure/Runtime/Interfaces/IDispatcher.cs
+++ b/OLED-Sleeper/Infrastructure/Runtime/Interfaces/IDispatcher.cs
@@ -23,5 +23,13 @@ namespace OLED_Sleeper.Infrastructure.Runtime.Interfaces
         /// <param name="action">The action to run.</param>
         /// <returns>A task that completes once the action has finished.</returns>
         Task InvokeAsync(Action action);
+
+        /// <summary>
+        /// Hands the action to the UI thread to run after the input already queued there has been
+        /// processed. A modal dialog opened this way cannot be answered by the click that asked for it.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        /// <returns>A task that completes once the action has finished.</returns>
+        Task InvokeAfterInputAsync(Action action);
     }
 }

--- a/OLED-Sleeper/MainWindow.xaml.cs
+++ b/OLED-Sleeper/MainWindow.xaml.cs
@@ -1,5 +1,3 @@
-﻿using OLED_Sleeper.UI.ViewModels;
-using System.ComponentModel;
 using System.Windows;
 using System.Windows.Input;
 
@@ -7,7 +5,7 @@ namespace OLED_Sleeper
 {
     /// <summary>
     /// The main application window for OLED Sleeper.
-    /// Handles window chrome, custom title bar, and delegates closing logic to the ViewModel.
+    /// Handles window chrome and the custom title bar.
     /// </summary>
     public partial class MainWindow : Window
     {
@@ -19,25 +17,6 @@ namespace OLED_Sleeper
         }
 
         #endregion Constructor
-
-        #region Window Event Overrides
-
-        /// <summary>
-        /// Handles the window closing event, delegating logic to the ViewModel.
-        /// Cancels closing if the ViewModel returns false.
-        /// </summary>
-        /// <param name="e">CancelEventArgs for the closing event.</param>
-        protected override void OnClosing(CancelEventArgs e)
-        {
-            if (DataContext is MainViewModel viewModel && !viewModel.OnWindowClosing())
-            {
-                e.Cancel = true;
-                return;
-            }
-            base.OnClosing(e);
-        }
-
-        #endregion Window Event Overrides
 
         #region Title Bar & Window Controls
 

--- a/OLED-Sleeper/UI/Services/Interfaces/IMainWindowAccessor.cs
+++ b/OLED-Sleeper/UI/Services/Interfaces/IMainWindowAccessor.cs
@@ -12,11 +12,5 @@ namespace OLED_Sleeper.UI.Services.Interfaces
         /// </summary>
         /// <param name="window">The window to register.</param>
         void SetMainWindow(Window window);
-
-        /// <summary>
-        /// Hides the main window. Does nothing when no main window has been registered.
-        /// Must be called on the UI thread.
-        /// </summary>
-        void HideMainWindow();
     }
 }

--- a/OLED-Sleeper/UI/Services/Interfaces/IMainWindowAccessor.cs
+++ b/OLED-Sleeper/UI/Services/Interfaces/IMainWindowAccessor.cs
@@ -12,5 +12,10 @@ namespace OLED_Sleeper.UI.Services.Interfaces
         /// </summary>
         /// <param name="window">The window to register.</param>
         void SetMainWindow(Window window);
+
+        /// <summary>
+        /// The registered main window, or null before one has been registered. Must be read on the UI thread.
+        /// </summary>
+        Window? MainWindow { get; }
     }
 }

--- a/OLED-Sleeper/UI/Services/Interfaces/IMainWindowService.cs
+++ b/OLED-Sleeper/UI/Services/Interfaces/IMainWindowService.cs
@@ -1,7 +1,8 @@
 namespace OLED_Sleeper.UI.Services.Interfaces
 {
     /// <summary>
-    /// Provides methods to set up, show, and activate the main application window.
+    /// Provides methods to set up, show, and activate the main application window, and decides what
+    /// closing it does.
     /// </summary>
     public interface IMainWindowService
     {
@@ -15,5 +16,10 @@ namespace OLED_Sleeper.UI.Services.Interfaces
         /// Brings the main window to the foreground and restores it if minimized.
         /// </summary>
         void ShowMainWindow();
+
+        /// <summary>
+        /// Stops the window being hidden on close, for the closes WPF performs as the application exits.
+        /// </summary>
+        void PrepareForShutdown();
     }
 }

--- a/OLED-Sleeper/UI/Services/Interfaces/IUnsavedSettings.cs
+++ b/OLED-Sleeper/UI/Services/Interfaces/IUnsavedSettings.cs
@@ -1,0 +1,25 @@
+namespace OLED_Sleeper.UI.Services.Interfaces
+{
+    /// <summary>
+    /// The monitor settings currently being edited, and what can be done with the edits.
+    /// Every member must be called on the UI thread.
+    /// </summary>
+    public interface IUnsavedSettings
+    {
+        /// <summary>
+        /// Whether any monitor has changes that have not been written to disk.
+        /// </summary>
+        bool IsDirty { get; }
+
+        /// <summary>
+        /// Validates the current settings and writes them.
+        /// </summary>
+        /// <returns>False when validation rejected the settings and nothing was written.</returns>
+        bool TrySaveChanges();
+
+        /// <summary>
+        /// Returns every monitor to the values it last had on disk.
+        /// </summary>
+        void DiscardChanges();
+    }
+}

--- a/OLED-Sleeper/UI/Services/Interfaces/IUnsavedSettingsService.cs
+++ b/OLED-Sleeper/UI/Services/Interfaces/IUnsavedSettingsService.cs
@@ -1,0 +1,21 @@
+namespace OLED_Sleeper.UI.Services.Interfaces
+{
+    /// <summary>
+    /// Asks the user what to do about unsaved monitor settings before an action that would lose them.
+    /// Both members block on a modal dialog and must be called on the UI thread.
+    /// </summary>
+    public interface IUnsavedSettingsService
+    {
+        /// <summary>
+        /// Asks before the settings window is hidden.
+        /// </summary>
+        /// <returns>True to go ahead and hide the window, false to leave it as it is.</returns>
+        bool ConfirmHide();
+
+        /// <summary>
+        /// Asks before the application exits.
+        /// </summary>
+        /// <returns>True to go ahead and exit, false to keep the application running.</returns>
+        bool ConfirmExit();
+    }
+}

--- a/OLED-Sleeper/UI/Services/MainWindowAccessor.cs
+++ b/OLED-Sleeper/UI/Services/MainWindowAccessor.cs
@@ -12,8 +12,5 @@ namespace OLED_Sleeper.UI.Services
     {
         /// <inheritdoc />
         public void SetMainWindow(Window window) => Application.Current.MainWindow = window;
-
-        /// <inheritdoc />
-        public void HideMainWindow() => Application.Current.MainWindow?.Hide();
     }
 }

--- a/OLED-Sleeper/UI/Services/MainWindowAccessor.cs
+++ b/OLED-Sleeper/UI/Services/MainWindowAccessor.cs
@@ -12,5 +12,8 @@ namespace OLED_Sleeper.UI.Services
     {
         /// <inheritdoc />
         public void SetMainWindow(Window window) => Application.Current.MainWindow = window;
+
+        /// <inheritdoc />
+        public Window? MainWindow => Application.Current?.MainWindow;
     }
 }

--- a/OLED-Sleeper/UI/Services/MainWindowService.cs
+++ b/OLED-Sleeper/UI/Services/MainWindowService.cs
@@ -2,29 +2,35 @@ using Microsoft.Extensions.Options;
 using OLED_Sleeper.Infrastructure.Hosting;
 using OLED_Sleeper.UI.Services.Interfaces;
 using OLED_Sleeper.UI.ViewModels;
+using System.ComponentModel;
 using System.Windows;
 
 namespace OLED_Sleeper.UI.Services
 {
     /// <summary>
-    /// Provides methods to set up, show, and activate the main window.
+    /// Provides methods to set up, show, and activate the main window, and hides it rather than
+    /// letting it close.
     /// </summary>
     public class MainWindowService(
         MainWindow mainWindow,
         MainViewModel mainViewModel,
         IOptions<ApplicationOptions> options,
-        IMainWindowAccessor mainWindowAccessor) : IMainWindowService
+        IMainWindowAccessor mainWindowAccessor,
+        IUnsavedSettingsService unsavedSettingsService) : IMainWindowService
     {
         private readonly ApplicationOptions _options = options.Value;
 
         /// <summary>
-        /// Sets up the main window as the application's main window, assigns its data context, 
-        /// and determines its initial visibility based on the configured application options.
+        /// True once the application has started exiting.
         /// </summary>
+        private bool _isShuttingDown;
+
+        /// <inheritdoc />
         public void SetupMainWindow()
         {
             mainWindowAccessor.SetMainWindow(mainWindow);
             mainWindow.DataContext = mainViewModel;
+            mainWindow.Closing += OnMainWindowClosing;
 
             if (_options.StartHidden)
             {
@@ -36,9 +42,7 @@ namespace OLED_Sleeper.UI.Services
             }
         }
 
-        /// <summary>
-        /// Brings the main window to the foreground and restores it if minimized.
-        /// </summary>
+        /// <inheritdoc />
         public void ShowMainWindow()
         {
             mainWindow.Show();
@@ -47,6 +51,25 @@ namespace OLED_Sleeper.UI.Services
                 mainWindow.WindowState = WindowState.Normal;
             }
             mainWindow.Activate();
+        }
+
+        /// <inheritdoc />
+        public void PrepareForShutdown() => _isShuttingDown = true;
+
+        /// <summary>
+        /// Hides the window instead of closing it, once the user has answered for any unsaved settings.
+        /// The close is left alone during shutdown.
+        /// </summary>
+        private void OnMainWindowClosing(object? sender, CancelEventArgs e)
+        {
+            if (_isShuttingDown) return;
+
+            e.Cancel = true;
+
+            if (unsavedSettingsService.ConfirmHide())
+            {
+                mainWindow.Hide();
+            }
         }
     }
 }

--- a/OLED-Sleeper/UI/Services/MessageBoxDialogService.cs
+++ b/OLED-Sleeper/UI/Services/MessageBoxDialogService.cs
@@ -5,17 +5,46 @@ using System.Windows;
 namespace OLED_Sleeper.UI.Services
 {
     /// <summary>
-    /// Shows dialogs through <see cref="MessageBox"/>.
+    /// Shows dialogs through <see cref="MessageBox"/>, owned by the main window whenever it is on screen.
+    /// An unowned dialog is positioned against whatever window Windows considers active, which for a dialog
+    /// raised from the tray menu is the menu's own popup, under the pointer.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class MessageBoxDialogService : IDialogService
+    public class MessageBoxDialogService(IMainWindowAccessor mainWindowAccessor) : IDialogService
     {
         /// <inheritdoc />
-        public MessageBoxResult AskYesNoCancel(string message, string caption) =>
-            MessageBox.Show(message, caption, MessageBoxButton.YesNoCancel, MessageBoxImage.Warning);
+        public MessageBoxResult AskYesNoCancel(string message, string caption)
+        {
+            var owner = Owner();
+
+            return owner == null
+                ? MessageBox.Show(message, caption, MessageBoxButton.YesNoCancel, MessageBoxImage.Warning)
+                : MessageBox.Show(owner, message, caption, MessageBoxButton.YesNoCancel, MessageBoxImage.Warning);
+        }
 
         /// <inheritdoc />
-        public void ShowError(string message, string caption) =>
-            MessageBox.Show(message, caption, MessageBoxButton.OK, MessageBoxImage.Error);
+        public void ShowError(string message, string caption)
+        {
+            var owner = Owner();
+
+            if (owner == null)
+            {
+                MessageBox.Show(message, caption, MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            MessageBox.Show(owner, message, caption, MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+
+        /// <summary>
+        /// The window to own the dialog. Null when no main window has been registered or it is off screen,
+        /// as it is for the storage failure reported before the window exists.
+        /// </summary>
+        private Window? Owner()
+        {
+            var window = mainWindowAccessor.MainWindow;
+
+            return window?.IsVisible == true ? window : null;
+        }
     }
 }

--- a/OLED-Sleeper/UI/Services/UnsavedSettingsService.cs
+++ b/OLED-Sleeper/UI/Services/UnsavedSettingsService.cs
@@ -1,0 +1,41 @@
+using OLED_Sleeper.UI.Services.Interfaces;
+using System.Windows;
+
+namespace OLED_Sleeper.UI.Services
+{
+    /// <summary>
+    /// Prompts through <see cref="IDialogService"/>, saving the settings on Yes and discarding them on No.
+    /// </summary>
+    public class UnsavedSettingsService(
+        IUnsavedSettings unsavedSettings,
+        IDialogService dialogService) : IUnsavedSettingsService
+    {
+        private const string Caption = "Unsaved Changes";
+
+        /// <inheritdoc />
+        public bool ConfirmHide() =>
+            Confirm("You have unsaved changes. Would you like to save them before hiding the window?");
+
+        /// <inheritdoc />
+        public bool ConfirmExit() =>
+            Confirm("You have unsaved changes. Would you like to save them before exiting?");
+
+        /// <summary>
+        /// Prompts only when there is something to lose. Yes answers with whether the save succeeded;
+        /// No discards the changes.
+        /// </summary>
+        private bool Confirm(string question)
+        {
+            if (!unsavedSettings.IsDirty) return true;
+
+            var result = dialogService.AskYesNoCancel(question, Caption);
+
+            if (result == MessageBoxResult.Cancel) return false;
+
+            if (result == MessageBoxResult.Yes) return unsavedSettings.TrySaveChanges();
+
+            unsavedSettings.DiscardChanges();
+            return true;
+        }
+    }
+}

--- a/OLED-Sleeper/UI/ViewModels/MainViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MainViewModel.cs
@@ -13,7 +13,7 @@ namespace OLED_Sleeper.UI.ViewModels
     /// The main ViewModel for the application's main window.
     /// It orchestrates the various services and manages the overall state of the UI.
     /// </summary>
-    public class MainViewModel : ViewModelBase
+    public class MainViewModel : ViewModelBase, IUnsavedSettings
     {
         #region Private Fields
 
@@ -31,16 +31,6 @@ namespace OLED_Sleeper.UI.ViewModels
         /// Runs actions on the UI thread.
         /// </summary>
         private readonly IDispatcher _dispatcher;
-
-        /// <summary>
-        /// Reaches the application's main window.
-        /// </summary>
-        private readonly IMainWindowAccessor _mainWindowAccessor;
-
-        /// <summary>
-        /// Shows modal dialogs to the user.
-        /// </summary>
-        private readonly IDialogService _dialogService;
 
         /// <summary>
         /// The width of the container used for monitor layout calculations.
@@ -187,20 +177,16 @@ namespace OLED_Sleeper.UI.ViewModels
         public MainViewModel(
             IWorkspaceService workspaceService,
             IMonitorSettingsSaveService saveService,
-            IDispatcher dispatcher,
-            IMainWindowAccessor mainWindowAccessor,
-            IDialogService dialogService)
+            IDispatcher dispatcher)
         {
             _workspaceService = workspaceService;
             _saveService = saveService;
             _dispatcher = dispatcher;
-            _mainWindowAccessor = mainWindowAccessor;
-            _dialogService = dialogService;
 
             SelectMonitorCommand = new RelayCommand(ExecuteSelectMonitor);
             ReloadMonitorsCommand = new RelayCommand(() => RefreshMonitors(false));
             SaveSettingsCommand = new AsyncRelayCommand(ExecuteSaveSettings, () => IsDirty);
-            DiscardChangesCommand = new RelayCommand(ExecuteDiscardChanges, () => IsDirty);
+            DiscardChangesCommand = new RelayCommand(DiscardChanges, () => IsDirty);
         }
 
         #endregion Constructor
@@ -226,31 +212,24 @@ namespace OLED_Sleeper.UI.ViewModels
             ApplyWorkspace(_workspaceService.BuildWorkspaceAsync, width, height, preserveSelection: true);
         }
 
-        /// <summary>
-        /// Handles logic for when the main window is closing. Returns true if the window should close, false to cancel.
-        /// </summary>
-        /// <returns>True to allow closing, false to cancel.</returns>
-        public bool OnWindowClosing()
+        /// <inheritdoc />
+        public bool TrySaveChanges()
         {
-            if (IsDirty)
+            if (!_saveService.TrySave(Monitors)) return false;
+
+            CheckDirtyState();
+            return true;
+        }
+
+        /// <inheritdoc />
+        public void DiscardChanges()
+        {
+            foreach (var monitor in Monitors)
             {
-                var result = _dialogService.AskYesNoCancel(
-                    "You have unsaved changes. Would you like to save them before hiding the window?",
-                    "Unsaved Changes");
-
-                if (result == MessageBoxResult.Cancel)
-                {
-                    return false; // Cancel closing
-                }
-
-                if (result == MessageBoxResult.Yes)
-                {
-                    SaveSettingsCommand.Execute(null);
-                }
+                monitor.Configuration.Revert();
             }
-            _mainWindowAccessor.HideMainWindow();
 
-            return false;
+            CheckDirtyState();
         }
 
         #endregion Public Methods (for View Interaction)
@@ -267,24 +246,11 @@ namespace OLED_Sleeper.UI.ViewModels
         }
 
         /// <summary>
-        /// Handles discarding unsaved changes by refreshing the monitor list.
-        /// </summary>
-        private void ExecuteDiscardChanges()
-        {
-            RefreshMonitors(true);
-        }
-
-        /// <summary>
         /// Saves the monitor settings and reports the outcome on the save button.
         /// </summary>
         private async Task ExecuteSaveSettings()
         {
-            if (!_saveService.TrySave(Monitors))
-            {
-                return; // Stop if invalid
-            }
-
-            CheckDirtyState();
+            if (!TrySaveChanges()) return;
 
             await ProvideSaveFeedbackAsync();
         }

--- a/OLED-Sleeper/UI/ViewModels/MonitorConfigurationViewModel.cs
+++ b/OLED-Sleeper/UI/ViewModels/MonitorConfigurationViewModel.cs
@@ -320,6 +320,23 @@ namespace OLED_Sleeper.UI.ViewModels
         }
 
         /// <summary>
+        /// Returns every tracked property to the value it had when the configuration was last saved.
+        /// </summary>
+        public void Revert()
+        {
+            IsManaged = _initialIsManaged;
+            Behavior = _initialBehavior;
+            DimLevel = _initialDimLevel;
+            LowerBrightnessOnBlackout = _initialLowerBrightnessOnBlackout;
+            IdleValue = _initialIdleValue;
+            SelectedTimeUnit = _initialSelectedTimeUnit;
+            IsActiveOnInput = _initialIsActiveOnInput;
+            IsActiveOnMousePosition = _initialIsActiveOnMousePosition;
+            IsActiveOnActiveWindow = _initialIsActiveOnActiveWindow;
+            UpdateDirtyState();
+        }
+
+        /// <summary>
         /// Applies settings from a MonitorSettings model to this ViewModel.
         /// </summary>
         /// <param name="settings">The settings to apply.</param>


### PR DESCRIPTION
Brings the blackout brightness default and the tray exit prompt onto `master` so `v2.2.0` can be released.

* The `v2.2.0` tag has to be re-pointed after this merges. It sits on `c114e0e`, which predates both, and its draft release should be deleted along with the tag so the release run does not add a second one.
* Tray Exit asks about unsaved monitor settings instead of discarding them (#98). Answering No discards the edits, and a save rejected by validation stops the exit and leaves the app running.
* A blackout no longer drops hardware brightness to zero unless the option is turned on for that monitor (#97). A settings file written before the option existed now reads as off.
