### PR TITLE
chore: release the blackout brightness-drop default fix

### DIFF
--- a/OLED-Sleeper.Tests/Features/MonitorBlackout/Handlers/ApplyBlackoutOverlayCommandHandlerTests.cs
+++ b/OLED-Sleeper.Tests/Features/MonitorBlackout/Handlers/ApplyBlackoutOverlayCommandHandlerTests.cs
@@ -29,11 +29,11 @@ namespace OLED_Sleeper.Tests.Features.MonitorBlackout.Handlers
         }
 
         [Fact]
-        public async Task HandleAsync_WhenDdcCiSupported_CallsOverlayAndDimming()
+        public async Task HandleAsync_WhenDdcCiSupportedAndLowerBrightnessRequested_CallsOverlayAndDimming()
         {
             // Arrange
             var hardwareId = "MON-123";
-            var command = new ApplyBlackoutOverlayCommand { HardwareId = hardwareId };
+            var command = new ApplyBlackoutOverlayCommand { HardwareId = hardwareId, LowerBrightness = true };
 
             var monitors = new List<MonitorInfo>
             {
@@ -56,6 +56,32 @@ namespace OLED_Sleeper.Tests.Features.MonitorBlackout.Handlers
             // Assert
             _monitorBlackoutServiceMock.Verify(x => x.ShowBlackoutOverlayAsync(hardwareId, It.IsAny<Rect>()), Times.Once);
             _monitorDimmingServiceMock.Verify(x => x.DimMonitorAsync(hardwareId, 0), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenLowerBrightnessNotRequested_CallsOverlayOnly()
+        {
+            // Arrange
+            var hardwareId = "MON-123";
+            var command = new ApplyBlackoutOverlayCommand { HardwareId = hardwareId };
+
+            var monitors = new List<MonitorInfo>
+            {
+                new MonitorInfo { HardwareId = hardwareId, Capabilities = new DdcCiCapabilities(true, 100), Bounds = new Rect(0, 0, 1920, 1080) }
+            };
+
+            SetupMonitors(monitors);
+
+            _monitorBlackoutServiceMock
+                .Setup(x => x.ShowBlackoutOverlayAsync(It.IsAny<string>(), It.IsAny<Rect>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            await _handler.HandleAsync(command);
+
+            // Assert
+            _monitorBlackoutServiceMock.Verify(x => x.ShowBlackoutOverlayAsync(hardwareId, It.IsAny<Rect>()), Times.Once);
+            _monitorDimmingServiceMock.Verify(x => x.DimMonitorAsync(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
         }
 
         [Fact]

--- a/OLED-Sleeper/Features/MonitorBlackout/Commands/ApplyBlackoutOverlayCommand.cs
+++ b/OLED-Sleeper/Features/MonitorBlackout/Commands/ApplyBlackoutOverlayCommand.cs
@@ -15,8 +15,8 @@ namespace OLED_Sleeper.Features.MonitorBlackout.Commands
         public required string HardwareId { get; init; }
 
         /// <summary>
-        /// Whether to also set the monitor's hardware brightness to zero. True when unset.
+        /// Whether to also set the monitor's hardware brightness to zero. False when unset.
         /// </summary>
-        public bool LowerBrightness { get; init; } = true;
+        public bool LowerBrightness { get; init; } = false;
     }
 }


### PR DESCRIPTION
Releases the blackout brightness-drop default fix from `develop` onto `master`.

* `ApplyBlackoutOverlayCommand.LowerBrightness` now defaults to false, matching the stored `MonitorSettings.LowerBrightnessOnBlackout` default, so a blackout leaves hardware brightness alone unless the caller asks for the drop.
* Tagging this merge commit with `v*` is what starts the release workflow.
